### PR TITLE
Rename `_` prefix on viewmodel meta-attributes to `$`

### DIFF
--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -4,11 +4,11 @@ require 'jbuilder'
 require 'deep_preloader'
 
 class ViewModel
-  REFERENCE_ATTRIBUTE = "_ref"
+  REFERENCE_ATTRIBUTE = "$ref"
   ID_ATTRIBUTE        = "id"
-  TYPE_ATTRIBUTE      = "_type"
-  VERSION_ATTRIBUTE   = "_version"
-  NEW_ATTRIBUTE       = "_new"
+  TYPE_ATTRIBUTE      = "$type"
+  VERSION_ATTRIBUTE   = "$version"
+  NEW_ATTRIBUTE       = "$new"
 
   class << self
     attr_accessor :_attributes

--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -12,7 +12,7 @@ class ViewModel::ActiveRecord < ViewModel::Record
   # Defined before requiring components so components can refer to them at parse time
 
   # for functional updates
-  FUNCTIONAL_UPDATE_TYPE = "_update"
+  FUNCTIONAL_UPDATE_TYPE = "$update"
   ACTIONS_ATTRIBUTE      = "actions"
   VALUES_ATTRIBUTE       = "values"
   BEFORE_ATTRIBUTE       = "before"

--- a/lib/view_model/active_record/update_data.rb
+++ b/lib/view_model/active_record/update_data.rb
@@ -425,8 +425,8 @@ class ViewModel::ActiveRecord
                                     viewmodel_reference_only] })
 
       # Referenced updates are special:
-      #  - Append requires `_ref` hashes
-      #  - Update requires `_ref` hashes
+      #  - Append requires `$ref` hashes
+      #  - Update requires `$ref` hashes
       #  - Remove requires vm refs (type/id)
       # Checked in code (ReferencedCollectionUpdate::Builder.parse_*_values)
 
@@ -484,10 +484,10 @@ class ViewModel::ActiveRecord
     end
 
     def [](name)
-      case name
-      when :id
+      case name.to_s
+      when ViewModel::ID_ATTRIBUTE
         id
-      when :_type
+      when ViewModel::TYPE_ATTRIBUTE
         viewmodel_class.view_name
       else
         attributes.fetch(name) { associations.fetch(name) { referenced_associations.fetch(name) }}
@@ -495,8 +495,8 @@ class ViewModel::ActiveRecord
     end
 
     def has_key?(name)
-      case name
-      when :id, :_type
+      case name.to_s
+      when ViewModel::ID_ATTRIBUTE, ViewModel::TYPE_ATTRIBUTE
         true
       else
         attributes.has_key?(name) || associations.has_key?(name) || referenced_associations.has_key?(name)

--- a/test/helpers/arvm_test_utilities.rb
+++ b/test/helpers/arvm_test_utilities.rb
@@ -47,7 +47,7 @@ module ARVMTestUtilities
   # Construct an update hash that references an existing model. Does not include
   # any of the model's attributes or association.
   def update_hash_for(viewmodel_class, model)
-    refhash = {'_type' => viewmodel_class.view_name, 'id' => model.id}
+    refhash = {'$type' => viewmodel_class.view_name, 'id' => model.id}
     yield(refhash) if block_given?
     refhash
   end

--- a/test/unit/view_model/active_record/belongs_to_test.rb
+++ b/test/unit/view_model/active_record/belongs_to_test.rb
@@ -94,12 +94,12 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
   def test_serialize_view
     view, _refs = serialize_with_references(ParentView.new(@parent1))
 
-    assert_equal({ "_type"    => "Parent",
-                   "_version" => 1,
+    assert_equal({ '$type'    => "Parent",
+                   '$version' => 1,
                    "id"       => @parent1.id,
                    "name"     => @parent1.name,
-                   "label"    => { "_type"    => "Label",
-                                   "_version" => 1,
+                   "label"    => { '$type'    => "Label",
+                                   '$version' => 1,
                                    "id"       => @parent1.label.id,
                                    "text"     => @parent1.label.text },
                  },
@@ -117,9 +117,9 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
 
   def test_create_from_view
     view = {
-      "_type"    => "Parent",
+      '$type'    => "Parent",
       "name"     => "p",
-      "label"    => { "_type" => "Label", "text" => "l" },
+      "label"    => { '$type' => "Label", "text" => "l" },
     }
 
     pv = ParentView.deserialize_from_view(view)
@@ -135,13 +135,13 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
   end
 
   def test_create_belongs_to_nil
-    view = { '_type' => 'Parent', 'name' => 'p', 'label' => nil }
+    view = { '$type' => 'Parent', 'name' => 'p', 'label' => nil }
     pv = ParentView.deserialize_from_view(view)
     assert_nil(pv.model.label)
   end
 
   def test_create_invalid_child_type
-    view = { '_type' => 'Parent', 'name' => 'p', 'label' => { '_type' => 'Parent', 'name' => 'q' } }
+    view = { '$type' => 'Parent', 'name' => 'p', 'label' => { '$type' => 'Parent', 'name' => 'q' } }
     ex = assert_raises(ViewModel::DeserializationError) do
       ParentView.deserialize_from_view(view)
     end
@@ -152,7 +152,7 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
     @parent1.update(label: nil)
 
     alter_by_view!(ParentView, @parent1) do |view, refs|
-      view['label'] = { '_type' => 'Label', 'text' => 'cheese' }
+      view['label'] = { '$type' => 'Label', 'text' => 'cheese' }
     end
 
     assert_equal('cheese', @parent1.label.text)
@@ -162,7 +162,7 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
     old_label = @parent1.label
 
     alter_by_view!(ParentView, @parent1) do |view, refs|
-      view['label'] = { '_type' => 'Label', 'text' => 'cheese' }
+      view['label'] = { '$type' => 'Label', 'text' => 'cheese' }
     end
 
     assert_equal('cheese', @parent1.label.text)
@@ -239,7 +239,7 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
     taken_label_ref = update_hash_for(LabelView, @parent1.label)
     ex = assert_raises(ViewModel::DeserializationError) do
       ParentView.deserialize_from_view(
-        [{ '_type' => 'Parent',
+        [{ '$type' => 'Parent',
            'name'  => 'newp',
            'label' => taken_label_ref }])
     end
@@ -260,7 +260,7 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
       old_label = owner.deleted
 
       alter_by_view!(OwnerView, owner) do |ov, refs|
-        ov['deleted'] = { '_type' => 'Label', 'text' => 'two' }
+        ov['deleted'] = { '$type' => 'Label', 'text' => 'two' }
       end
 
       assert_equal('two', owner.deleted.text)
@@ -273,7 +273,7 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
       old_label = owner.ignored
 
       alter_by_view!(OwnerView, owner) do |ov, refs|
-        ov['ignored'] = { '_type' => 'Label', 'text' => 'two' }
+        ov['ignored'] = { '$type' => 'Label', 'text' => 'two' }
       end
       assert_equal('two', owner.ignored.text)
       refute_equal(old_label, owner.ignored)
@@ -314,7 +314,7 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
     end
 
     def test_dependencies
-      root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent', 'something_else' => nil }])
+      root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '$type' => 'Parent', 'something_else' => nil }])
       assert_equal(DeepPreloader::Spec.new('label' => DeepPreloader::Spec.new), root_updates.first.preload_dependencies(ref_updates))
       assert_equal({ 'something_else' => {} }, root_updates.first.updated_associations)
     end
@@ -322,8 +322,8 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
     def test_renamed_roundtrip
       alter_by_view!(ParentView, @parent) do |view, refs|
         assert_equal({ 'id'       => @parent.label.id,
-                       '_type'    => 'Label',
-                       '_version' => 1,
+                       '$type'    => 'Label',
+                       '$version' => 1,
                        'text'     => 'l1' },
                      view['something_else'])
         view['something_else']['text'] = 'new l1 text'

--- a/test/unit/view_model/active_record/controller_test.rb
+++ b/test/unit/view_model/active_record/controller_test.rb
@@ -50,12 +50,12 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
 
   def test_create
     data = {
-        '_type'    => 'Parent',
+        '$type'    => 'Parent',
         'name'     => 'p2',
-        'label'    => { '_type' => 'Label', 'text' => 'l' },
-        'target'   => { '_type' => 'Target', 'text' => 't' },
-        'children' => [{ '_type' => 'Child', 'name' => 'c1' },
-                       { '_type' => 'Child', 'name' => 'c2' }]
+        'label'    => { '$type' => 'Label', 'text' => 'l' },
+        'target'   => { '$type' => 'Target', 'text' => 't' },
+        'children' => [{ '$type' => 'Child', 'name' => 'c1' },
+                       { '$type' => 'Child', 'name' => 'c2' }]
     }
 
     parentcontroller = ParentController.new(data: data)
@@ -87,7 +87,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
 
   def test_update
     data = { 'id'    => @parent.id,
-             '_type' => 'Parent',
+             '$type' => 'Parent',
              'name'  => 'new' }
 
     parentcontroller = ParentController.new(id: @parent.id, data: data)
@@ -122,13 +122,13 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     assert_equal({ 'errors' => [{ 'status' => 404,
                                   'detail' => "Couldn't find Parent with 'id'=9999",
                                   'code'   => "Deserialization.NotFound",
-                                  'meta' => { 'nodes' => [{ '_type' => "Parent", 'id' => 9999 }]}}]},
+                                  'meta' => { 'nodes' => [{ '$type' => "Parent", 'id' => 9999 }]}}]},
                  parentcontroller.hash_response)
   end
 
   def test_create_invalid_shallow_validation
-    data = { '_type'    => 'Parent',
-             'children' => [{ '_type' => 'Child',
+    data = { '$type'    => 'Parent',
+             'children' => [{ '$type' => 'Child',
                               'age'   => 42 }] }
 
     parentcontroller = ParentController.new(data: data)
@@ -137,14 +137,14 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     assert_equal({ 'errors' => [{ 'status' => 400,
                                   'detail' => 'Validation failed: Age must be less than 42',
                                   'code'   => "Deserialization.Validation",
-                                  'meta' => { 'nodes' => [{ '_type' => "Child", 'id' => nil }],
+                                  'meta' => { 'nodes' => [{ '$type' => "Child", 'id' => nil }],
                                               'validation_errors' => { 'age' => ["must be less than 42"]}}}] },
                  parentcontroller.hash_response)
   end
 
   def test_create_invalid_shallow_constraint
-    data = { '_type'    => 'Parent',
-             'children' => [{ '_type' => 'Child',
+    data = { '$type'    => 'Parent',
+             'children' => [{ '$type' => 'Child',
                               'age'   => 1 }] }
     parentcontroller = ParentController.new(data: data)
     parentcontroller.invoke(:create)
@@ -162,7 +162,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     assert_equal({ 'errors' => [{ 'status' => 404,
                                   'detail' => "Couldn't find Parent with 'id'=9999",
                                   'code'   => "Deserialization.NotFound",
-                                  'meta' => { "nodes" => [{"_type" => "Parent", "id" => 9999}]}}] },
+                                  'meta' => { "nodes" => [{'$type' => "Parent", "id" => 9999}]}}] },
                  parentcontroller.hash_response)
     assert_equal(404, parentcontroller.status)
   end
@@ -181,7 +181,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
   end
 
   def test_nested_collection_append_one
-    data = { '_type' => 'Child', 'name' => 'c3' }
+    data = { '$type' => 'Child', 'name' => 'c3' }
     childcontroller = ChildController.new(parent_id: @parent.id, data: data)
 
     childcontroller.invoke(:append)
@@ -196,8 +196,8 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
   end
 
   def test_nested_collection_append_many
-    data = [{ '_type' => 'Child', 'name' => 'c3' },
-            { '_type' => 'Child', 'name' => 'c4' }]
+    data = [{ '$type' => 'Child', 'name' => 'c3' },
+            { '$type' => 'Child', 'name' => 'c4' }]
 
     childcontroller = ChildController.new(parent_id: @parent.id, data: data)
     childcontroller.invoke(:append)
@@ -216,8 +216,8 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     # Parent.children
     old_children = @parent.children
 
-    data = [{'_type' => 'Child', 'name' => 'newc1'},
-            {'_type' => 'Child', 'name' => 'newc2'}]
+    data = [{'$type' => 'Child', 'name' => 'newc1'},
+            {'$type' => 'Child', 'name' => 'newc2'}]
 
     childcontroller = ChildController.new(parent_id: @parent.id, data: data)
     childcontroller.invoke(:create)
@@ -284,7 +284,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     old_child = @parent.children.first
 
     data = { 'id' => old_child.id,
-             '_type' => 'Child',
+             '$type' => 'Child',
              'name' => 'new_name' }
 
     childcontroller = ChildController.new(data: data)
@@ -317,7 +317,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
   def test_nested_singular_replace_from_parent
     old_label = @parent.label
 
-    data = {'_type' => 'Label', 'text' => 'new label'}
+    data = {'$type' => 'Label', 'text' => 'new label'}
     labelcontroller = LabelController.new(parent_id: @parent.id, data: data)
     labelcontroller.invoke(:create)
 
@@ -325,8 +325,8 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
 
     @parent.reload
 
-    assert_equal({ 'data' => { '_type'    => 'Label',
-                               '_version' => 1,
+    assert_equal({ 'data' => { '$type'    => 'Label',
+                               '$version' => 1,
                                'id'       => @parent.label.id,
                                'text'     => 'new label' } },
                  labelcontroller.hash_response)
@@ -365,7 +365,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
   def test_nested_singular_update
     old_label = @parent.label
 
-    data = {'_type' => 'Label', 'id' => old_label.id, 'text' => 'new label'}
+    data = {'$type' => 'Label', 'id' => old_label.id, 'text' => 'new label'}
     labelcontroller = LabelController.new(data: data)
     labelcontroller.invoke(:create)
 

--- a/test/unit/view_model/active_record/counter_test.rb
+++ b/test/unit/view_model/active_record/counter_test.rb
@@ -51,7 +51,7 @@ class ViewModel::ActiveRecord::CounterTest < ActiveSupport::TestCase
 
   def test_counter_cache_create
     alter_by_view!(CategoryView, @category1) do |view, refs|
-      view['products'] << {'_type' => 'Product'}
+      view['products'] << {'$type' => 'Product'}
     end
     assert_equal(2, @category1.products_count)
   end

--- a/test/unit/view_model/active_record/customization_test.rb
+++ b/test/unit/view_model/active_record/customization_test.rb
@@ -30,7 +30,7 @@ class ViewModel::ActiveRecord::SpecializeAssociationTest < ActiveSupport::TestCa
 
         def self.pre_parse_translations(viewmodel_reference, hash, translations)
           raise "type check" unless translations.is_a?(Hash) && translations.all? { |k, v| k.is_a?(String) && v.is_a?(String) }
-          hash["translations"] = translations.map { |lang, text| { "_type" => "Translation", "language" => lang, "translation" => text } }
+          hash["translations"] = translations.map { |lang, text| { '$type' => "Translation", "language" => lang, "translation" => text } }
         end
 
         def resolve_translations(update_datas, previous_translation_views)
@@ -77,8 +77,8 @@ class ViewModel::ActiveRecord::SpecializeAssociationTest < ActiveSupport::TestCa
 
     @text1_view = {
       "id"           => @text1.id,
-      "_type"        => "Text",
-      "_version"     => 1,
+      '$type'        => "Text",
+      '$version'     => 1,
       "text"         => "dog",
       "translations" => {
         "ja" => "犬",
@@ -162,7 +162,7 @@ class ViewModel::ActiveRecord::FlattenAssociationTest < ActiveSupport::TestCase
           raise "nopes" if members.present?
           nil
         else
-          members.merge("_type" => viewmodel.view_name)
+          members.merge('$type' => viewmodel.view_name)
         end
       end
 
@@ -225,8 +225,8 @@ class ViewModel::ActiveRecord::FlattenAssociationTest < ActiveSupport::TestCase
     @simplesection = Section.create(name: "simple1")
     @simplesection_view = {
       "id"           => @simplesection.id,
-      "_type"        => "Section",
-      "_version"     => 1,
+      '$type'        => "Section",
+      '$version'     => 1,
       "section_type" => "Simple",
       "name"         => "simple1"
     }
@@ -234,8 +234,8 @@ class ViewModel::ActiveRecord::FlattenAssociationTest < ActiveSupport::TestCase
     @quizsection = Section.create(name: "quiz1", section_data: QuizSection.new(quiz_name: "qq"))
     @quizsection_view = {
       "id"           => @quizsection.id,
-      "_type"        => "Section",
-      "_version"     => 1,
+      '$type'        => "Section",
+      '$version'     => 1,
       "section_type" => "Quiz",
       "name"         => "quiz1",
       "quiz_name"    => "qq"
@@ -244,8 +244,8 @@ class ViewModel::ActiveRecord::FlattenAssociationTest < ActiveSupport::TestCase
     @vocabsection = Section.create(name: "vocab1", section_data: VocabSection.new(vocab_word: "dog"))
     @vocabsection_view = {
       "id"           => @vocabsection.id,
-      "_type"        => "Section",
-      "_version"     => 1,
+      '$type'        => "Section",
+      '$version'     => 1,
       "section_type" => "Vocab",
       "name"         => "vocab1",
       "vocab_word"   => "dog"

--- a/test/unit/view_model/active_record/has_many_test.rb
+++ b/test/unit/view_model/active_record/has_many_test.rb
@@ -82,12 +82,12 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     view, _refs = serialize_with_references(ParentView.new(@parent1))
 
 
-    assert_equal({ "_type"    => "Parent",
-                   "_version" => 1,
+    assert_equal({ '$type'    => "Parent",
+                   '$version' => 1,
                    "id"       => @parent1.id,
                    "name"     => @parent1.name,
-                   "children" => @parent1.children.map { |child| { "_type"    => "Child",
-                                                                   "_version" => 1,
+                   "children" => @parent1.children.map { |child| { '$type'    => "Child",
+                                                                   '$version' => 1,
                                                                    "id"       => child.id,
                                                                    "name"     => child.name } } },
                  view)
@@ -103,10 +103,10 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_create_from_view
     view = {
-      "_type"    => "Parent",
+      '$type'    => "Parent",
       "name"     => "p",
-      "children" => [{ "_type" => "Child", "name" => "c1" },
-                     { "_type" => "Child", "name" => "c2" }]
+      "children" => [{ '$type' => "Child", "name" => "c1" },
+                     { '$type' => "Child", "name" => "c2" }]
     }
 
     pv = ParentView.deserialize_from_view(view)
@@ -130,7 +130,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     assert_raises(ViewModel::DeserializationError) do
       # append child
-      ParentView.new(@parent1).append_associated(:children, { "_type" => "Child", "text" => "hi" }, deserialize_context: no_edit_context)
+      ParentView.new(@parent1).append_associated(:children, { '$type' => "Child", "text" => "hi" }, deserialize_context: no_edit_context)
     end
 
     assert_raises(ViewModel::DeserializationError) do
@@ -140,16 +140,16 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
   end
 
   def test_create_has_many_empty
-    view = { '_type' => 'Parent', 'name' => 'p', 'children' => [] }
+    view = { '$type' => 'Parent', 'name' => 'p', 'children' => [] }
     pv = ParentView.deserialize_from_view(view)
     assert(pv.model.children.blank?)
   end
 
   def test_create_has_many
-    view = { '_type'    => 'Parent',
+    view = { '$type'    => 'Parent',
              'name'     => 'p',
-             'children' => [{ '_type' => 'Child', 'name' => 'c1' },
-                            { '_type' => 'Child', 'name' => 'c2' }] }
+             'children' => [{ '$type' => 'Child', 'name' => 'c1' },
+                            { '$type' => 'Child', 'name' => 'c2' }] }
 
     context = ViewModelBase::new_deserialize_context
     pv = ParentView.deserialize_from_view(view, deserialize_context: context)
@@ -163,7 +163,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_nil_multiple_association
     view = {
-       "_type" => "Parent",
+       '$type' => "Parent",
       "children" => nil
     }
     ex = assert_raises(ViewModel::DeserializationError) do
@@ -175,8 +175,8 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_non_array_multiple_association
     view = {
-      "_type" => "Parent",
-      "children" => { '_type' => 'Child', 'name' => 'c1' }
+      '$type' => "Parent",
+      "children" => { '$type' => 'Child', 'name' => 'c1' }
     }
     ex = assert_raises(ViewModel::DeserializationError) do
       ParentView.deserialize_from_view(view)
@@ -189,7 +189,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     old_children = @parent1.children
 
     alter_by_view!(ParentView, @parent1) do |view, refs|
-      view['children'] = [{ '_type' => 'Child', 'name' => 'new_child' }]
+      view['children'] = [{ '$type' => 'Child', 'name' => 'new_child' }]
     end
 
     assert_equal(['new_child'], @parent1.children.map(&:name))
@@ -203,7 +203,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     context = ParentView.new_deserialize_context
 
     nc = pv.replace_associated(:children,
-                               [{ '_type' => 'Child', 'name' => 'new_child' }],
+                               [{ '$type' => 'Child', 'name' => 'new_child' }],
                                deserialize_context: context)
 
 
@@ -262,7 +262,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     c1, c2, c3 = @parent1.children.order(:position).to_a
     _, context = alter_by_view!(ParentView, @parent1) do |view, refs|
       view['children'].shift
-      view['children'] << { '_type' => 'Child', 'name' => 'new_c' }
+      view['children'] << { '$type' => 'Child', 'name' => 'new_c' }
     end
 
     assert_equal({ ViewModel::Reference.new(ParentView, @parent1.id) => 1,
@@ -285,7 +285,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     # insert before
     pv.append_associated(:children,
-                         { '_type' => 'Child', 'id' => c3.id },
+                         { '$type' => 'Child', 'id' => c3.id },
                          before: ViewModel::Reference.new(ChildView, c1.id),
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
@@ -297,7 +297,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     # insert after
     pv.append_associated(:children,
-                         { '_type' => 'Child', 'id' => c3.id },
+                         { '$type' => 'Child', 'id' => c3.id },
                          after: ViewModel::Reference.new(ChildView, c1.id),
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
@@ -308,7 +308,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     # append
     pv.append_associated(:children,
-                         { '_type' => 'Child', 'id' => c3.id },
+                         { '$type' => 'Child', 'id' => c3.id },
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
     assert_equal([c1, c2, c3],
@@ -340,7 +340,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     # insert before
     pv.append_associated(:children,
-                         { '_type' => 'Child', 'name' => 'new1' },
+                         { '$type' => 'Child', 'name' => 'new1' },
                          before: ViewModel::Reference.new(ChildView, c2.id),
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
@@ -353,7 +353,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     # insert after
     pv.append_associated(:children,
-                         { '_type' => 'Child', 'name' => 'new2' },
+                         { '$type' => 'Child', 'name' => 'new2' },
                          after: ViewModel::Reference.new(ChildView, c2.id),
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
@@ -366,7 +366,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     # append
     pv.append_associated(:children,
-                         { '_type' => 'Child', 'name' => 'new3' },
+                         { '$type' => 'Child', 'name' => 'new3' },
                          deserialize_context: (context = ParentView.new_deserialize_context))
 
     n3 = Child.find_by_name("new3")
@@ -380,7 +380,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     alter_by_view!(ParentView, @parent1) do |view, refs|
       view['children'].reverse!
-      view['children'].insert(1, { '_type' => 'Child', 'name' => 'new_c' })
+      view['children'].insert(1, { '$type' => 'Child', 'name' => 'new_c' })
     end
 
     assert_equal([c3, Child.find_by_name('new_c'), c2, c1],
@@ -389,9 +389,9 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_edit_missing_child
     view = {
-      "_type" => "Parent",
+      '$type' => "Parent",
       "children" => [{
-                       "_type" => "Child",
+                       '$type' => "Child",
                        "id"    => 9999
                      }]
     }
@@ -409,13 +409,13 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     moved_child_ref = update_hash_for(ChildView, moved_child)
 
-    view = { '_type'    => 'Parent',
+    view = { '$type'    => 'Parent',
              'name'     => 'new_p',
              'children' => [moved_child_ref,
-                            { '_type' => 'Child', 'name' => 'new' }] }
+                            { '$type' => 'Child', 'name' => 'new' }] }
 
     retained_children = old_children - [moved_child]
-    release_view = { '_type'    => 'Parent',
+    release_view = { '$type'    => 'Parent',
                      'id'       => @parent1.id,
                      'children' => retained_children.map { |c| update_hash_for(ChildView, c) } }
 
@@ -442,10 +442,10 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     moved_child_ref = update_hash_for(ChildView, moved_child)
 
-    view = { '_type'    => 'Parent',
+    view = { '$type'    => 'Parent',
              'name'     => 'new_p',
              'children' => [moved_child_ref,
-                            { '_type' => 'Child', 'name' => 'new' }] }
+                            { '$type' => 'Child', 'name' => 'new' }] }
 
     deserialize_context = ViewModelBase.new_deserialize_context
 
@@ -473,7 +473,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_implicit_release_has_many
     old_children = @parent1.children.order(:position)
-    view = {'_type'    => 'Parent',
+    view = {'$type'    => 'Parent',
             'name'     => 'newp',
             'children' => old_children.map { |x| update_hash_for(ChildView, x) }}
 
@@ -493,7 +493,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     assert_raises(ViewModel::DeserializationError) do
       ParentView.deserialize_from_view(
-        [{ '_type'    => 'Parent',
+        [{ '$type'    => 'Parent',
            'name'     => 'newp',
            'children' => old_children_refs },
          update_hash_for(ParentView, @parent1) { |p1v| p1v['name'] = 'p1 new name' }])
@@ -508,7 +508,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     view['children'] << ChildView.new(moved_child).to_hash
 
     retained_children = old_children - [moved_child]
-    release_view = { '_type' => 'Parent', 'id' => @parent1.id,
+    release_view = { '$type' => 'Parent', 'id' => @parent1.id,
                      'children' => retained_children.map { |c| update_hash_for(ChildView, c) }}
 
     ParentView.deserialize_from_view([view, release_view])
@@ -526,7 +526,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
   end
 
   def test_has_many_append_child
-    ParentView.new(@parent1).append_associated(:children, { "_type" => "Child", "name" => "new" })
+    ParentView.new(@parent1).append_associated(:children, { '$type' => "Child", "name" => "new" })
 
     @parent1.reload
 
@@ -559,7 +559,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     p1c2 = @parent1.children[1]
     assert_equal(2, p1c2.position)
 
-    ParentView.new(@parent2).append_associated("children", { "_type" => "Child", "id" => p1c2.id })
+    ParentView.new(@parent2).append_associated("children", { '$type' => "Child", "id" => p1c2.id })
 
     @parent1.reload
     @parent2.reload
@@ -597,15 +597,15 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     child_view = ChildView.new(child).to_hash
     child_view["name"] = "changed"
 
-    view = { "_type" => "Parent",
+    view = { '$type' => "Parent",
              "name" => "new_p",
-             "children" => [child_view, { "_type" => "Child", "name" => "new" }]}
+             "children" => [child_view, { '$type' => "Child", "name" => "new" }]}
 
     # TODO this is as awkward here as it is in the application
-    release_view = { "_type" => "Parent",
+    release_view = { '$type' => "Parent",
                      "id" => @parent1.id,
-                     "children" => [{ "_type" => "Child", "id" => @parent1.children[0].id },
-                                    { "_type" => "Child", "id" => @parent1.children[2].id }]}
+                     "children" => [{ '$type' => "Child", "id" => @parent1.children[0].id },
+                                    { '$type' => "Child", "id" => @parent1.children[2].id }]}
 
     pv = ParentView.deserialize_from_view([view, release_view])
     new_parent = pv.first.model
@@ -633,9 +633,9 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     view = ParentView.new(@parent2).to_hash
     view["children"] << old_child_view
 
-    release_view = {"_type" => "Parent", "id" => @parent1.id,
-                    "children" => [{"_type" => "Child", "id" => @parent1.children[0].id},
-                                   {"_type" => "Child", "id" => @parent1.children[2].id}]}
+    release_view = {'$type' => "Parent", "id" => @parent1.id,
+                    "children" => [{'$type' => "Child", "id" => @parent1.children[0].id},
+                                   {'$type' => "Child", "id" => @parent1.children[2].id}]}
 
     ParentView.deserialize_from_view([view, release_view])
 
@@ -662,13 +662,13 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_functional_update_append
     children_before = @parent1.children.order(:position).pluck(:id)
-    append_view     = { '_type'    => 'Parent',
+    append_view     = { '$type'    => 'Parent',
                         'id'       => @parent1.id,
                         'children' => {
-                          '_type'   => '_update',
-                          'actions' => [{ '_type'  => 'append',
-                                          'values' => [{ '_type' => 'Child' },
-                                                       { '_type' => 'Child' }] }] } }
+                          '$type'   => '$update',
+                          'actions' => [{ '$type'  => 'append',
+                                          'values' => [{ '$type' => 'Child' },
+                                                       { '$type' => 'Child' }] }] } }
     result          = ParentView.deserialize_from_view(append_view)
     @parent1.reload
 
@@ -680,14 +680,14 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_functional_update_append_before_mid
     c1, c2, c3  = @parent1.children.order(:position)
-    append_view = { '_type'    => 'Parent',
+    append_view = { '$type'    => 'Parent',
                     'id'       => @parent1.id,
                     'children' => {
-                      '_type'   => '_update',
-                      'actions' => [{ '_type'  => 'append',
-                                      'before' => { '_type' => 'Child', 'id' => c2.id },
-                                      'values' => [{ '_type' => 'Child', 'name' => 'new c1' },
-                                                   { '_type' => 'Child', 'name' => 'new c2' }] }] } }
+                      '$type'   => '$update',
+                      'actions' => [{ '$type'  => 'append',
+                                      'before' => { '$type' => 'Child', 'id' => c2.id },
+                                      'values' => [{ '$type' => 'Child', 'name' => 'new c1' },
+                                                   { '$type' => 'Child', 'name' => 'new c2' }] }] } }
     ParentView.deserialize_from_view(append_view)
     @parent1.reload
 
@@ -697,13 +697,13 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_functional_update_append_before_reorder
     c1, c2, c3  = @parent1.children.order(:position)
-    append_view = { '_type'    => 'Parent',
+    append_view = { '$type'    => 'Parent',
                     'id'       => @parent1.id,
                     'children' => {
-                      '_type'   => '_update',
-                      'actions' => [{ '_type'  => 'append',
-                                      'before' => { '_type' => 'Child', 'id' => c2.id },
-                                      'values' => [{ '_type' => 'Child', 'id' => c3.id }] }] } }
+                      '$type'   => '$update',
+                      'actions' => [{ '$type'  => 'append',
+                                      'before' => { '$type' => 'Child', 'id' => c2.id },
+                                      'values' => [{ '$type' => 'Child', 'id' => c3.id }] }] } }
     ParentView.deserialize_from_view(append_view)
     @parent1.reload
 
@@ -713,14 +713,14 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_functional_update_append_before_beginning
     c1, c2, c3  = @parent1.children.order(:position)
-    append_view = { '_type'    => 'Parent',
+    append_view = { '$type'    => 'Parent',
                     'id'       => @parent1.id,
                     'children' => {
-                      '_type'   => '_update',
-                      'actions' => [{ '_type'  => 'append',
-                                      'before' => { '_type' => 'Child', 'id' => c1.id },
-                                      'values' => [{ '_type' => 'Child', 'name' => 'new c1' },
-                                                   { '_type' => 'Child', 'name' => 'new c2' }] }] } }
+                      '$type'   => '$update',
+                      'actions' => [{ '$type'  => 'append',
+                                      'before' => { '$type' => 'Child', 'id' => c1.id },
+                                      'values' => [{ '$type' => 'Child', 'name' => 'new c1' },
+                                                   { '$type' => 'Child', 'name' => 'new c2' }] }] } }
     ParentView.deserialize_from_view(append_view)
     @parent1.reload
 
@@ -731,14 +731,14 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
   def test_functional_update_append_before_corpse
     _, c2, _ = @parent1.children.order(:position)
     c2.destroy
-    append_view = { '_type'    => 'Parent',
+    append_view = { '$type'    => 'Parent',
                     'id'       => @parent1.id,
                     'children' => {
-                      '_type'   => '_update',
-                      'actions' => [{ '_type'  => 'append',
-                                      'before' => { '_type' => 'Child', 'id' => c2.id },
-                                      'values' => [{ '_type' => 'Child', 'name' => 'new c1' },
-                                                   { '_type' => 'Child', 'name' => 'new c2' }] }] } }
+                      '$type'   => '$update',
+                      'actions' => [{ '$type'  => 'append',
+                                      'before' => { '$type' => 'Child', 'id' => c2.id },
+                                      'values' => [{ '$type' => 'Child', 'name' => 'new c1' },
+                                                   { '$type' => 'Child', 'name' => 'new c2' }] }] } }
     assert_raises(ViewModel::DeserializationError) do
       ParentView.deserialize_from_view(append_view)
     end
@@ -746,14 +746,14 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_functional_update_append_after_mid
     c1, c2, c3  = @parent1.children.order(:position)
-    append_view = { '_type'    => 'Parent',
+    append_view = { '$type'    => 'Parent',
                     'id'       => @parent1.id,
                     'children' => {
-                      '_type'   => '_update',
-                      'actions' => [{ '_type'  => 'append',
-                                      'after'  => { '_type' => 'Child', 'id' => c2.id },
-                                      'values' => [{ '_type' => 'Child', 'name' => 'new c1' },
-                                                   { '_type' => 'Child', 'name' => 'new c2' }] }] } }
+                      '$type'   => '$update',
+                      'actions' => [{ '$type'  => 'append',
+                                      'after'  => { '$type' => 'Child', 'id' => c2.id },
+                                      'values' => [{ '$type' => 'Child', 'name' => 'new c1' },
+                                                   { '$type' => 'Child', 'name' => 'new c2' }] }] } }
     ParentView.deserialize_from_view(append_view)
     @parent1.reload
 
@@ -763,14 +763,14 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_functional_update_append_after_end
     c1, c2, c3  = @parent1.children.order(:position)
-    append_view = { '_type'    => 'Parent',
+    append_view = { '$type'    => 'Parent',
                     'id'       => @parent1.id,
                     'children' => {
-                      '_type'   => '_update',
-                      'actions' => [{ '_type'  => 'append',
-                                      'after'  => { '_type' => 'Child', 'id' => c3.id, },
-                                      'values' => [{ '_type' => 'Child', 'name' => 'new c1' },
-                                                   { '_type' => 'Child', 'name' => 'new c2' }] }] } }
+                      '$type'   => '$update',
+                      'actions' => [{ '$type'  => 'append',
+                                      'after'  => { '$type' => 'Child', 'id' => c3.id, },
+                                      'values' => [{ '$type' => 'Child', 'name' => 'new c1' },
+                                                   { '$type' => 'Child', 'name' => 'new c2' }] }] } }
     ParentView.deserialize_from_view(append_view)
     @parent1.reload
 
@@ -781,14 +781,14 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
   def test_functional_update_append_after_corpse
     _, c2, _ = @parent1.children.order(:position)
     c2.destroy
-    append_view = { '_type'    => 'Parent',
+    append_view = { '$type'    => 'Parent',
                     'id'       => @parent1.id,
                     'children' => {
-                      '_type'   => '_update',
-                      'actions' => [{ '_type'  => 'append',
-                                      'after'  => { '_type' => 'Child', 'id' => c2.id },
-                                      'values' => [{ '_type' => 'Child', 'name' => 'new c1' },
-                                                   { '_type' => 'Child', 'name' => 'new c2' }] }] } }
+                      '$type'   => '$update',
+                      'actions' => [{ '$type'  => 'append',
+                                      'after'  => { '$type' => 'Child', 'id' => c2.id },
+                                      'values' => [{ '$type' => 'Child', 'name' => 'new c1' },
+                                                   { '$type' => 'Child', 'name' => 'new c2' }] }] } }
     assert_raises(ViewModel::DeserializationError) do
       ParentView.deserialize_from_view(append_view)
     end
@@ -796,12 +796,12 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_functional_update_remove_success
     c1_id, c2_id, c3_id = @parent1.children.pluck(:id)
-    remove_view         = { '_type'    => 'Parent',
+    remove_view         = { '$type'    => 'Parent',
                             'id'       => @parent1.id,
                             'children' => {
-                              '_type'   => '_update',
-                              'actions' => [{ '_type'  => 'remove',
-                                              'values' => [{ '_type' => 'Child', 'id' => c2_id }] }] } }
+                              '$type'   => '$update',
+                              'actions' => [{ '$type'  => 'remove',
+                                              'values' => [{ '$type' => 'Child', 'id' => c2_id }] }] } }
     ParentView.deserialize_from_view(remove_view)
     @parent1.reload
 
@@ -810,12 +810,12 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_functional_update_remove_failure
     c_id        = @parent1.children.pluck(:id).first
-    remove_view = { '_type'    => 'Parent',
+    remove_view = { '$type'    => 'Parent',
                     'id'       => @parent1.id,
                     'children' => {
-                      '_type'   => '_update',
-                      'actions' => [{ '_type'  => 'remove',
-                                      'values' => [{ '_type' => 'Child',
+                      '$type'   => '$update',
+                      'actions' => [{ '$type'  => 'remove',
+                                      'values' => [{ '$type' => 'Child',
                                                      'id'    => c_id,
                                                      'name'  => 'remove and update disallowed' }] }] } }
 
@@ -823,17 +823,17 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
       ParentView.deserialize_from_view(remove_view)
     end
 
-    assert_match(/Removed entities must have only _type and id fields/, ex.message)
+    assert_match(/Removed entities must have only \$type and id fields/, ex.message)
   end
 
   def test_functional_update_update_success
     c1_id, c2_id, c3_id = @parent1.children.pluck(:id)
-    update_view         = { '_type'    => 'Parent',
+    update_view         = { '$type'    => 'Parent',
                             'id'       => @parent1.id,
                             'children' => {
-                              '_type'   => '_update',
-                              'actions' => [{ '_type'  => 'update',
-                                              'values' => [{ '_type' => 'Child',
+                              '$type'   => '$update',
+                              'actions' => [{ '$type'  => 'update',
+                                              'values' => [{ '$type' => 'Child',
                                                              'id'    => c2_id,
                                                              'name'  => 'Functionally Updated Child' }] }] } }
     ParentView.deserialize_from_view(update_view)
@@ -845,12 +845,12 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_functional_update_update_failure
     cnew                = Child.create(parent: Parent.create).id
-    update_view         = { '_type'    => 'Parent',
+    update_view         = { '$type'    => 'Parent',
                             'id'       => @parent1.id,
                             'children' => {
-                              '_type'   => '_update',
-                              'actions' => [{ '_type'  => 'update',
-                                              'values' => [{ '_type' => 'Child', 'id' => cnew }] }] } }
+                              '$type'   => '$update',
+                              'actions' => [{ '$type'  => 'update',
+                                              'values' => [{ '$type' => 'Child', 'id' => cnew }] }] } }
 
     ex = assert_raises(ViewModel::DeserializationError::NotFound) do
       ParentView.deserialize_from_view(update_view)
@@ -861,15 +861,15 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
   def test_functional_update_duplicate_refs
     child_id    = @parent1.children.pluck(:id).first
-    update_view = { '_type'    => 'Parent',
+    update_view = { '$type'    => 'Parent',
                     'id'       => @parent1.id,
                     'children' => {
-                      '_type'   => '_update',
+                      '$type'   => '$update',
                       # remove and append the same child
-                      'actions' => [{ '_type'  => 'remove',
-                                      'values' => [{ '_type' => 'Child', 'id' => child_id }] },
-                                    { '_type'  => 'append',
-                                      'values' => [{ '_type' => 'Child', 'id' => child_id }] }] } }
+                      'actions' => [{ '$type'  => 'remove',
+                                      'values' => [{ '$type' => 'Child', 'id' => child_id }] },
+                                    { '$type'  => 'append',
+                                      'values' => [{ '$type' => 'Child', 'id' => child_id }] }] } }
 
     ex = assert_raises(ViewModel::DeserializationError) do
       ParentView.deserialize_from_view(update_view)
@@ -912,7 +912,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     end
 
     def test_dependencies
-      root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent', 'something_else' => [] }])
+      root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '$type' => 'Parent', 'something_else' => [] }])
       assert_equal(DeepPreloader::Spec.new('children' => DeepPreloader::Spec.new), root_updates.first.preload_dependencies(ref_updates))
       assert_equal({ 'something_else' => {} }, root_updates.first.updated_associations)
     end
@@ -920,8 +920,8 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     def test_renamed_roundtrip
       alter_by_view!(ParentView, @parent) do |view, refs|
         assert_equal([{ 'id'       => @parent.children.first.id,
-                        '_type'    => 'Child',
-                        '_version' => 1,
+                        '$type'    => 'Child',
+                        '$version' => 1,
                         'name'     => 'c1' }],
                      view['something_else'])
         view['something_else'][0]['name'] = 'new c1 name'

--- a/test/unit/view_model/active_record/has_many_through_poly_test.rb
+++ b/test/unit/view_model/active_record/has_many_through_poly_test.rb
@@ -139,14 +139,14 @@ class ViewModel::ActiveRecord::HasManyThroughPolyTest < ActiveSupport::TestCase
     # TODO not part of ARVM; but depends on the particular context from #before_all
     # If we refactor out the contexts from their tests, this should go in another test file.
 
-    root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent' }])
+    root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '$type' => 'Parent' }])
     assert_equal(DeepPreloader::Spec.new,
                  root_updates.first.preload_dependencies(ref_updates),
                  'nothing loaded by default')
 
-    root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent',
-                                                                                  'tags' => [{ '_ref' => 'r1' }] }],
-                                                                               { 'r1' => { '_type' => 'TagB' } })
+    root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '$type' => 'Parent',
+                                                                                  'tags' => [{ '$ref' => 'r1' }] }],
+                                                                               { 'r1' => { '$type' => 'TagB' } })
 
     assert_equal(DeepPreloader::Spec.new(
                   'parents_tags' => DeepPreloader::Spec.new(
@@ -160,20 +160,20 @@ class ViewModel::ActiveRecord::HasManyThroughPolyTest < ActiveSupport::TestCase
     view, refs = serialize_with_references(ParentView.new(@parent1),
                                            serialize_context: context_with(:tags))
 
-    tag_data = view['tags'].map { |hash| refs[hash['_ref']] }
-    assert_equal([{ 'id' => @tag_a1.id, '_type' => 'TagA', '_version' => 1, 'name' => 'tag A1' },
-                  { 'id' => @tag_a2.id, '_type' => 'TagA', '_version' => 1, 'name' => 'tag A2' },
-                  { 'id' => @tag_b1.id, '_type' => 'TagB', '_version' => 1, 'name' => 'tag B1' },
-                  { 'id' => @tag_b2.id, '_type' => 'TagB', '_version' => 1, 'name' => 'tag B2' }],
+    tag_data = view['tags'].map { |hash| refs[hash['$ref']] }
+    assert_equal([{ 'id' => @tag_a1.id, '$type' => 'TagA', '$version' => 1, 'name' => 'tag A1' },
+                  { 'id' => @tag_a2.id, '$type' => 'TagA', '$version' => 1, 'name' => 'tag A2' },
+                  { 'id' => @tag_b1.id, '$type' => 'TagB', '$version' => 1, 'name' => 'tag B1' },
+                  { 'id' => @tag_b2.id, '$type' => 'TagB', '$version' => 1, 'name' => 'tag B2' }],
                  tag_data)
   end
 
   def test_create_has_many_through
     alter_by_view!(ParentView, @parent1) do |view, refs|
-      refs.delete_if { |_, ref_hash| ref_hash['_type'] == 'Tag' }
-      refs['t1'] = { '_type' => 'TagA', 'name' => 'new tagA' }
-      refs['t2'] = { '_type' => 'TagB', 'name' => 'new tagB' }
-      view['tags'] = [{ '_ref' => 't1' }, { '_ref' => 't2' }]
+      refs.delete_if { |_, ref_hash| ref_hash['$type'] == 'Tag' }
+      refs['t1'] = { '$type' => 'TagA', 'name' => 'new tagA' }
+      refs['t2'] = { '$type' => 'TagB', 'name' => 'new tagB' }
+      view['tags'] = [{ '$ref' => 't1' }, { '$ref' => 't2' }]
     end
 
     new_tag_a = TagA.find_by_name('new tagA')
@@ -239,7 +239,7 @@ class ViewModel::ActiveRecord::HasManyThroughPolyTest < ActiveSupport::TestCase
     end
 
     def test_dependencies
-      root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent', 'something_else' => [] }])
+      root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '$type' => 'Parent', 'something_else' => [] }])
       # Compare to non-polymorphic, which will also load the tags
       deps = root_updates.first.preload_dependencies(ref_updates)
       assert_equal(DeepPreloader::Spec.new('parents_tags' => DeepPreloader::Spec.new('tag' => DeepPreloader::PolymorphicSpec.new)), deps)
@@ -251,15 +251,15 @@ class ViewModel::ActiveRecord::HasManyThroughPolyTest < ActiveSupport::TestCase
       context = ParentView.new_serialize_context(include: :something_else)
       alter_by_view!(ParentView, @parent, serialize_context: context) do |view, refs|
         assert_equal({refs.keys.first => { 'id'       => @parent.parents_tags.first.tag.id,
-                                           '_type'    => 'TagA',
-                                           '_version' => 1,
+                                           '$type'    => 'TagA',
+                                           '$version' => 1,
                                            'name'     => 'tag A name' }}, refs)
-        assert_equal([{ '_ref' => refs.keys.first }],
+        assert_equal([{ '$ref' => refs.keys.first }],
                      view['something_else'])
 
         refs.clear
-        refs['new'] = {'_type' => 'TagB', 'name' => 'tag B name'}
-        view['something_else'] = [{'_ref' => 'new'}]
+        refs['new'] = {'$type' => 'TagB', 'name' => 'tag B name'}
+        view['something_else'] = [{'$ref' => 'new'}]
       end
 
       assert_equal('tag B name', @parent.parents_tags.first.tag.name)

--- a/test/unit/view_model/active_record/has_one_test.rb
+++ b/test/unit/view_model/active_record/has_one_test.rb
@@ -76,9 +76,9 @@ class ViewModel::ActiveRecord::HasOneTest < ActiveSupport::TestCase
 
   def test_create_from_view
     view = {
-      "_type"    => "Parent",
+      '$type'    => "Parent",
       "name"     => "p",
-      "target"   => { "_type" => "Target", "text" => "t" },
+      "target"   => { '$type' => "Target", "text" => "t" },
     }
 
     pv = ParentView.deserialize_from_view(view)
@@ -96,12 +96,12 @@ class ViewModel::ActiveRecord::HasOneTest < ActiveSupport::TestCase
 
   def test_serialize_view
     view, _refs = serialize_with_references(ParentView.new(@parent1))
-    assert_equal({ "_type"    => "Parent",
-                   "_version" => 1,
+    assert_equal({ '$type'    => "Parent",
+                   '$version' => 1,
                    "id"       => @parent1.id,
                    "name"     => @parent1.name,
-                   "target"   => { "_type"    => "Target",
-                                   "_version" => 1,
+                   "target"   => { '$type'    => "Target",
+                                   '$version' => 1,
                                    "id"       => @parent1.target.id,
                                    "text"     => @parent1.target.text } },
                  view)
@@ -132,7 +132,7 @@ class ViewModel::ActiveRecord::HasOneTest < ActiveSupport::TestCase
   end
 
   def test_has_one_create_nil
-    view = { '_type' => 'Parent', 'name' => 'p', 'target' => nil }
+    view = { '$type' => 'Parent', 'name' => 'p', 'target' => nil }
     pv = ParentView.deserialize_from_view(view)
     assert_nil(pv.model.target)
   end
@@ -141,7 +141,7 @@ class ViewModel::ActiveRecord::HasOneTest < ActiveSupport::TestCase
     @parent1.update(target: nil)
 
     alter_by_view!(ParentView, @parent1) do |view, refs|
-      view['target'] = { '_type' => 'Target', 'text' => 't' }
+      view['target'] = { '$type' => 'Target', 'text' => 't' }
     end
 
     assert_equal('t', @parent1.target.text)
@@ -240,7 +240,7 @@ class ViewModel::ActiveRecord::HasOneTest < ActiveSupport::TestCase
 
   def test_bad_single_association
     view = {
-      "_type" => "Parent",
+      '$type' => "Parent",
       "target" => []
     }
     ex = assert_raises(ViewModel::DeserializationError) do
@@ -283,7 +283,7 @@ class ViewModel::ActiveRecord::HasOneTest < ActiveSupport::TestCase
     end
 
     def test_dependencies
-      root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent', 'something_else' => nil }])
+      root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '$type' => 'Parent', 'something_else' => nil }])
       assert_equal(DeepPreloader::Spec.new('target' => DeepPreloader::Spec.new), root_updates.first.preload_dependencies(ref_updates))
       assert_equal({ 'something_else' => {} }, root_updates.first.updated_associations)
     end
@@ -291,8 +291,8 @@ class ViewModel::ActiveRecord::HasOneTest < ActiveSupport::TestCase
     def test_renamed_roundtrip
       alter_by_view!(ParentView, @parent) do |view, refs|
         assert_equal({ 'id'       => @parent.target.id,
-                       '_type'    => 'Target',
-                       '_version' => 1,
+                       '$type'    => 'Target',
+                       '$version' => 1,
                        'text'     => 'target text' },
                      view['something_else'])
         view['something_else']['text'] = 'target new text'

--- a/test/unit/view_model/active_record/optional_attribute_view_test.rb
+++ b/test/unit/view_model/active_record/optional_attribute_view_test.rb
@@ -31,8 +31,8 @@ class ViewModel::ActiveRecord::AttributeViewTest < ActiveSupport::TestCase
     super
     @thing = Thing.create!(a: 1, b: 2)
 
-    @skel = { "_type"    => "Thing",
-              "_version" => 1,
+    @skel = { '$type'    => "Thing",
+              '$version' => 1,
               "id"       => @thing.id }
   end
 

--- a/test/unit/view_model/active_record/poly_test.rb
+++ b/test/unit/view_model/active_record/poly_test.rb
@@ -78,9 +78,9 @@ module ViewModel::ActiveRecord::PolyTest
 
     def test_create_has_one_from_view
       p1_view = {
-        "_type" => "PolyParentOne",
+        '$type' => "PolyParentOne",
         "text"  => "p",
-        "child" => { "_type" => "Child", "text" => "c" }
+        "child" => { '$type' => "Child", "text" => "c" }
       }
       p1v = PolyParentOneView.deserialize_from_view(p1_view)
       p1 = p1v.model
@@ -92,9 +92,9 @@ module ViewModel::ActiveRecord::PolyTest
 
     def test_create_has_many_from_view
       p2_view = {
-        "_type" => "PolyParentTwo",
+        '$type' => "PolyParentTwo",
         "num"   => "2",
-        "children" => [{ "_type" => "Child", "text" => "c1" }, { "_type" => "Child", "text" => "c2" }]
+        "children" => [{ '$type' => "Child", "text" => "c1" }, { '$type' => "Child", "text" => "c2" }]
       }
       p2v = PolyParentTwoView.deserialize_from_view(p2_view)
       p2 = p2v.model
@@ -203,9 +203,9 @@ module ViewModel::ActiveRecord::PolyTest
 
     def test_create_from_view
       view = {
-        "_type"    => "Parent",
+        '$type'    => "Parent",
         "name"     => "p",
-        "poly"     => { "_type" => "PolyTwo", "text" => "pol" }
+        "poly"     => { '$type' => "PolyTwo", "text" => "pol" }
       }
 
       pv = ParentView.deserialize_from_view(view)
@@ -225,12 +225,12 @@ module ViewModel::ActiveRecord::PolyTest
     def test_serialize_view
       view, _refs = serialize_with_references(ParentView.new(@parent1))
 
-      assert_equal({ "_type"    => "Parent",
-                     "_version" => 1,
+      assert_equal({ '$type'    => "Parent",
+                     '$version' => 1,
                      "id"       => @parent1.id,
                      "name"     => @parent1.name,
-                     "poly"     => { "_type"    => @parent1.poly_type,
-                                     "_version" => 1,
+                     "poly"     => { '$type'    => @parent1.poly_type,
+                                     '$version' => 1,
                                      "id"       => @parent1.poly.id,
                                      "number"   => @parent1.poly.number }
                    },
@@ -241,11 +241,11 @@ module ViewModel::ActiveRecord::PolyTest
     def test_invalid_type_lookup_with_version
       ex = assert_raises do
         ParentView.deserialize_from_view(
-          { '_type' => 'Parent',
-            '_new'  => true,
+          { '$type' => 'Parent',
+            '$new'  => true,
             'poly' => {
-              '_type'    => 'SomethingThatsNotActuallyAType',
-              '_version' => 1,
+              '$type'    => 'SomethingThatsNotActuallyAType',
+              '$version' => 1,
             } })
         end
         assert_match(/\binvalid\b.+\bviewmodel type\b/i, ex.message)
@@ -255,7 +255,7 @@ module ViewModel::ActiveRecord::PolyTest
       old_poly = @parent1.poly
 
       alter_by_view!(ParentView, @parent1) do |view, refs|
-        view['poly'] = { '_type' => 'PolyTwo', 'text' => 'hi' }
+        view['poly'] = { '$type' => 'PolyTwo', 'text' => 'hi' }
       end
 
       assert_instance_of(PolyTwo, @parent1.poly)
@@ -297,7 +297,7 @@ module ViewModel::ActiveRecord::PolyTest
       end
 
       def test_dependencies
-        root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent', 'something_else' => nil }])
+        root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '$type' => 'Parent', 'something_else' => nil }])
         assert_equal(DeepPreloader::Spec.new('poly' => DeepPreloader::PolymorphicSpec.new), root_updates.first.preload_dependencies(ref_updates))
         assert_equal({ 'something_else' => {} }, root_updates.first.updated_associations)
       end
@@ -305,11 +305,11 @@ module ViewModel::ActiveRecord::PolyTest
       def test_renamed_roundtrip
         alter_by_view!(ParentView, @parent) do |view, refs|
           assert_equal({ 'id'       => @parent.id,
-                         '_type'    => 'PolyOne',
-                         '_version' => 1,
+                         '$type'    => 'PolyOne',
+                         '$version' => 1,
                          'number'   => 42 },
                        view['something_else'])
-          view['something_else'] = {'_type' => 'PolyTwo', 'text' => 'hi'}
+          view['something_else'] = {'$type' => 'PolyTwo', 'text' => 'hi'}
         end
 
         assert_equal('hi', @parent.poly.text)

--- a/test/unit/view_model/active_record/shared_test.rb
+++ b/test/unit/view_model/active_record/shared_test.rb
@@ -83,12 +83,12 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
 
   def test_create_from_view
     view = {
-      "_type"    => "Parent",
+      '$type'    => "Parent",
       "name"     => "p",
-      "category"   => { "_ref" => "r1" },
+      "category"   => { '$ref' => "r1" },
     }
     refs = {
-      "r1" => { "_type" => "Category", "name" => "newcat"}
+      "r1" => { '$type' => "Category", "name" => "newcat"}
     }
 
     pv = ParentView.deserialize_from_view(view, references: refs)
@@ -105,19 +105,19 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
 
   def test_serialize_view
     view, refs = serialize_with_references(ParentView.new(@parent1), serialize_context: serialize_context)
-    cat1_ref = refs.detect { |_, v| v['_type'] == 'Category' }.first
+    cat1_ref = refs.detect { |_, v| v['$type'] == 'Category' }.first
 
-    assert_equal({cat1_ref => { '_type'    => "Category",
-                                "_version" => 1,
+    assert_equal({cat1_ref => { '$type'    => "Category",
+                                '$version' => 1,
                                 'id'       => @parent1.category.id,
                                 'name'     => @parent1.category.name }},
                  refs)
 
-    assert_equal({ "_type"    => "Parent",
-                   "_version" => 1,
+    assert_equal({ '$type'    => "Parent",
+                   '$version' => 1,
                    "id"       => @parent1.id,
                    "name"     => @parent1.name,
-                   "category" => { "_ref" => cat1_ref } },
+                   "category" => { '$ref' => cat1_ref } },
                  view)
   end
 
@@ -137,7 +137,7 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
                                             ParentView.new(@parent2)],
                                            serialize_context: ParentView.new_serialize_context(include: :category))
 
-    category_ref = view.first['category']['_ref']
+    category_ref = view.first['category']['$ref']
 
     assert_equal([category_ref], refs.keys,
                  'category referenced twice generates a single reference')
@@ -145,7 +145,7 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
 
   def test_shared_add_reference
     alter_by_view!(ParentView, @parent2, serialize_context: serialize_context) do |p2view, refs|
-      p2view['category'] = { '_ref' => 'myref' }
+      p2view['category'] = { '$ref' => 'myref' }
       refs['myref'] = update_hash_for(CategoryView, @category1)
     end
 
@@ -154,11 +154,11 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
 
   def test_shared_add_multiple_references
     alter_by_view!(ParentView, [@parent1, @parent2], serialize_context: serialize_context) do |(p1view, p2view), refs|
-      refs.delete(p1view['category']['_ref'])
+      refs.delete(p1view['category']['$ref'])
       refs['myref'] = update_hash_for(CategoryView, @category1)
 
-      p1view['category'] = { '_ref' => 'myref' }
-      p2view['category'] = { '_ref' => 'myref' }
+      p1view['category'] = { '$ref' => 'myref' }
+      p2view['category'] = { '$ref' => 'myref' }
     end
 
     assert_equal(@category1, @parent1.category)
@@ -168,7 +168,7 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
   def test_shared_requires_all_references
     ex = assert_raises(ViewModel::DeserializationError) do
       alter_by_view!(ParentView, @parent2, serialize_context: serialize_context) do |p2view, refs|
-        refs['spurious_ref'] = { '_type' => 'Parent', 'id' => @parent1.id }
+        refs['spurious_ref'] = { '$type' => 'Parent', 'id' => @parent1.id }
       end
     end
     assert_match(/References not referred to from roots/, ex.message)
@@ -188,7 +188,7 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
     ex = assert_raises(ViewModel::DeserializationError) do
       serialize_context = ParentView.new_serialize_context(include: :category)
       alter_by_view!(ParentView, @parent1, serialize_context: serialize_context) do |p1view, refs|
-        p1view['category'] = { '_ref' => 'p2' }
+        p1view['category'] = { '$ref' => 'p2' }
         refs['p2'] = update_hash_for(ParentView, @parent2)
       end
     end
@@ -202,8 +202,8 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
       alter_by_view!(ParentView, [@parent1, @parent2]) do |(p1view, p2view), refs|
         refs['c_a'] = c1_ref.dup
         refs['c_b'] = c1_ref.dup
-        p1view['category'] = { '_ref' => 'c_a' }
-        p2view['category'] = { '_ref' => 'c_b' }
+        p1view['category'] = { '$ref' => 'c_a' }
+        p2view['category'] = { '$ref' => 'c_b' }
       end
     end
     assert_match(/Duplicate/, ex.message)
@@ -212,7 +212,7 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
   def test_shared_updates_shared_data
     serialize_context = ParentView.new_serialize_context(include: :category)
     alter_by_view!(ParentView, @parent1, serialize_context: serialize_context) do |p1view, refs|
-      category_ref = p1view['category']['_ref']
+      category_ref = p1view['category']['$ref']
       refs[category_ref]['name'] = 'newcatname'
     end
     assert_equal('newcatname', @parent1.category.name)
@@ -221,7 +221,7 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
   def test_shared_delete_reference
     serialize_context = ParentView.new_serialize_context(include: :category)
     alter_by_view!(ParentView, @parent1, serialize_context: serialize_context) do |p1view, refs|
-      category_ref = p1view['category']['_ref']
+      category_ref = p1view['category']['$ref']
       refs.delete(category_ref)
       p1view['category'] = nil
     end
@@ -234,7 +234,7 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
     d_context = ParentView.new_deserialize_context
 
     alter_by_view!(ParentView, @parent1, serialize_context: serialize_context, deserialize_context: d_context) do |view, refs|
-      refs[view['category']["_ref"]]["name"] = "changed"
+      refs[view['category']['$ref']]["name"] = "changed"
     end
 
     assert(d_context.edit_checks.include?(ViewModel::Reference.new(CategoryView, @parent1.category.id)))
@@ -246,9 +246,9 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
     d_context = ParentView.new_deserialize_context
 
     alter_by_view!(ParentView, @parent1, serialize_context: serialize_context, deserialize_context: d_context) do |view, refs|
-      refs.delete(view['category']['_ref'])
-      view['category']['_ref'] = 'new_cat'
-      refs['new_cat'] = { "_type" => "Category", "name" => "new category"}
+      refs.delete(view['category']['$ref'])
+      view['category']['$ref'] = 'new_cat'
+      refs['new_cat'] = { '$type' => "Category", "name" => "new category"}
     end
 
     assert(d_context.edit_checks.include?(ViewModel::Reference.new(CategoryView, nil)))
@@ -260,7 +260,7 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
     d_context = ParentView.new_deserialize_context
 
     alter_by_view!(ParentView, @parent1, serialize_context: serialize_context, deserialize_context: d_context) do |view, refs|
-      refs.delete(view['category']['_ref'])
+      refs.delete(view['category']['$ref'])
       view['category'] = nil
     end
 

--- a/test/unit/view_model/active_record/version_test.rb
+++ b/test/unit/view_model/active_record/version_test.rb
@@ -60,22 +60,22 @@ class ViewModel::ActiveRecord::VersionTest < ActiveSupport::TestCase
 
     target_ref = refs.keys.first
 
-    assert_equal({ '_type'    => 'Parent',
+    assert_equal({ '$type'    => 'Parent',
                    'id'       => @parent_with_a.id,
-                   '_version' => 5,
+                   '$version' => 5,
                    'child'    => {
-                     '_type'    => 'ChildA',
+                     '$type'    => 'ChildA',
                      'id'       => @parent_with_a.child.id,
-                     '_version' => 10,
+                     '$version' => 10,
                    },
-                   'target'   => { '_ref' => target_ref } },
+                   'target'   => { '$ref' => target_ref } },
                  data)
 
     assert_equal({ target_ref =>
                      {
-                       '_type'    => 'Target',
+                       '$type'    => 'Target',
                        'id'       => @parent_with_a.target.id,
-                       '_version' => 20
+                       '$version' => 20
                      } },
                  refs)
   end
@@ -83,9 +83,9 @@ class ViewModel::ActiveRecord::VersionTest < ActiveSupport::TestCase
   def test_regular_version_verification
     ex = assert_raise(ViewModel::DeserializationError::SchemaMismatch) do
       ParentView.deserialize_from_view(
-        { '_type'    => 'Parent',
-          '_new'     => true,
-          '_version' => 99 },)
+        { '$type'    => 'Parent',
+          '$new'     => true,
+          '$version' => 99 },)
     end
     assert_match(/schema version/, ex.message)
   end
@@ -93,11 +93,11 @@ class ViewModel::ActiveRecord::VersionTest < ActiveSupport::TestCase
   def test_polymorphic_version_verification
     ex = assert_raise(ViewModel::DeserializationError::SchemaMismatch) do
       ParentView.deserialize_from_view(
-        { '_type' => 'Parent',
-          '_new'  => true,
+        { '$type' => 'Parent',
+          '$new'  => true,
           'child' => {
-            '_type'    => 'ChildA',
-            '_version' => 99,
+            '$type'    => 'ChildA',
+            '$version' => 99,
           } })
     end
     assert_match(/schema version/, ex.message)
@@ -106,14 +106,14 @@ class ViewModel::ActiveRecord::VersionTest < ActiveSupport::TestCase
   def test_shared_parse_version_verification
     ex = assert_raise(ViewModel::DeserializationError::SchemaMismatch) do
       ParentView.deserialize_from_view(
-        { '_type'  => 'Parent',
-          '_new'   => true,
-          'target' => { '_ref' => 't1' },
+        { '$type'  => 'Parent',
+          '$new'   => true,
+          'target' => { '$ref' => 't1' },
         },
         references: { 't1' => {
-          '_type'    => 'Target',
-          '_new'     => true,
-          '_version' => 99,
+          '$type'    => 'Target',
+          '$new'     => true,
+          '$version' => 99,
         } })
     end
     assert_match(/schema version/, ex.message)

--- a/test/unit/view_model/active_record_test.rb
+++ b/test/unit/view_model/active_record_test.rb
@@ -58,7 +58,7 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
   def test_create_from_view
     view = {
-      "_type"    => "Parent",
+      '$type'    => "Parent",
       "name"     => "p",
     }
 
@@ -73,10 +73,10 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
   def test_create_from_view_with_explicit_id
     view = {
-      "_type" => "Parent",
+      '$type' => "Parent",
       "id"    => 9999,
       "name"  => "p",
-      "_new"  => true
+      '$new'  => true
     }
     pv = ParentView.deserialize_from_view(view)
     p = pv.model
@@ -88,9 +88,9 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
   def test_create_explicit_id_raises_with_id
     view = {
-      "_type" => "Parent",
+      '$type' => "Parent",
       "id"    => 9999,
-      "_new"  => true
+      '$new'  => true
     }
     ex = assert_raises(ViewModel::DeserializationError) do
       ParentView.deserialize_from_view(view)
@@ -101,10 +101,10 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
   def test_read_only_raises_with_id
     view = {
-      "_type" => "Parent",
+      '$type' => "Parent",
       "one"   => 2,
       "id"    => 9999,
-      "_new"  => true
+      '$new'  => true
     }
     ex = assert_raises(ViewModel::DeserializationError) do
       ParentView.deserialize_from_view(view)
@@ -124,7 +124,7 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
   def test_editability_checks_create
     context = ViewModelBase.new_deserialize_context
-    ParentView.deserialize_from_view({'_type' => 'Parent', 'name' => 'p'},
+    ParentView.deserialize_from_view({'$type' => 'Parent', 'name' => 'p'},
                                         deserialize_context: context)
     assert_equal([ViewModel::Reference.new(ParentView, nil)], context.edit_checks)
   end
@@ -134,7 +134,7 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
     assert_raises(ViewModel::DeserializationError) do
       # create
-      ParentView.deserialize_from_view({ "_type" => "Parent", "name" => "p" }, deserialize_context: no_edit_context)
+      ParentView.deserialize_from_view({ '$type' => "Parent", "name" => "p" }, deserialize_context: no_edit_context)
     end
 
     assert_raises(ViewModel::DeserializationError) do
@@ -150,8 +150,8 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
   end
 
   def test_create_multiple
-    view = [{'_type' => 'Parent', 'name' => 'newp1'},
-            {'_type' => 'Parent', 'name' => 'newp2'}]
+    view = [{'$type' => 'Parent', 'name' => 'newp1'},
+            {'$type' => 'Parent', 'name' => 'newp2'}]
 
     result = ParentView.deserialize_from_view(view)
 
@@ -162,8 +162,8 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
   def test_update_duplicate_specification
     view = [
-      {'_type' => 'Parent', 'id' => @parent1.id},
-      {'_type' => 'Parent', 'id' => @parent1.id},
+      {'$type' => 'Parent', 'id' => @parent1.id},
+      {'$type' => 'Parent', 'id' => @parent1.id},
     ]
     ex = assert_raises(ViewModel::DeserializationError) do
       ParentView.deserialize_from_view(view)
@@ -182,15 +182,15 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
     ex = assert_raises(ViewModel::DeserializationError) do
       ParentView.deserialize_from_view({ "target" => [] })
     end
-    assert_match(/"_type" wasn't supplied/, ex.message)
+    assert_match(/"\$type" wasn't supplied/, ex.message)
 
     ex = assert_raises(ViewModel::DeserializationError) do
-      ParentView.deserialize_from_view({ "_type" => "Invalid" })
+      ParentView.deserialize_from_view({ '$type' => "Invalid" })
     end
     assert_match(/incorrect root viewmodel type/, ex.message)
 
     ex = assert_raises(ViewModel::DeserializationError) do
-      ParentView.deserialize_from_view({ "_type" => "NotAViewmodelType" })
+      ParentView.deserialize_from_view({ '$type' => "NotAViewmodelType" })
     end
     assert_match(/ViewModel\b.*\bnot found/, ex.message)
   end
@@ -222,7 +222,7 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
   def test_edit_missing_root
     view = {
-      "_type" => "Parent",
+      '$type' => "Parent",
       "id"    => 9999
     }
 
@@ -353,7 +353,7 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
        l = List.create!(car: 1)
 
        alter_by_view!(ListView, l) do |view, refs|
-         view["cdr"] = { "_type" => "List", "car" => 2 }
+         view["cdr"] = { '$type' => "List", "car" => 2 }
        end
 
        l_edits = edit_check(ViewModel::Reference.new(ListView, l.id))
@@ -368,7 +368,7 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
        l2 = l.cdr
 
        alter_by_view!(ListView, l) do |view, refs|
-         view["cdr"] = { "_type" => "List", "car" => 2 }
+         view["cdr"] = { '$type' => "List", "car" => 2 }
        end
 
        l_edits = edit_check(ViewModel::Reference.new(ListView, l.id))
@@ -439,15 +439,15 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
     def test_serialize_view
       view, _refs = serialize_with_references(PairView.new(@pair))
 
-      assert_equal({ "_type"    => "Pair",
-                     "_version" => 1,
+      assert_equal({ '$type'    => "Pair",
+                     '$version' => 1,
                      "id"       => @pair.id,
                      "pair"     => { "a" => 1, "b" => 2 } },
                    view)
     end
 
     def test_create
-      view = { "_type" => "Pair", "pair" => { "a" => 3, "b" => 4 } }
+      view = { '$type' => "Pair", "pair" => { "a" => 3, "b" => 4 } }
       pv = PairView.deserialize_from_view(view)
       assert_equal([3,4], pv.model.pair)
     end
@@ -503,11 +503,11 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
       end
 
       assert_equal({},
-                   updated_by_view.({ '_type' => 'Parent',
+                   updated_by_view.({ '$type' => 'Parent',
                                       'name' => 'p' }))
 
       assert_equal({ 'children' => {} },
-                   updated_by_view.({ '_type' => 'Parent',
+                   updated_by_view.({ '$type' => 'Parent',
                                       'name' => 'p',
                                       'children' => [] }))
     end
@@ -554,11 +554,11 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
     def test_deserialize_context
       view = {
-        "_type" => "List",
+        '$type' => "List",
         "id"    => 1000,
-        "_new"  => true,
+        '$new'  => true,
         "child" => {
-          "_type" => "List",
+          '$type' => "List",
         }}
 
       ref_error = assert_raises(RefError) do

--- a/test/unit/view_model/record_test.rb
+++ b/test/unit/view_model/record_test.rb
@@ -57,16 +57,16 @@ class ViewModel::RecordTest < ActiveSupport::TestCase
     @model = Model.new("simple", 2, "readonly", "writeonce", Model.new("child"), "optional")
 
     @view = {
-      "_type"      => "Model",
-      "_version"   => 1,
+      '$type'      => "Model",
+      '$version'   => 1,
       "simple"     => "simple",
       "overridden" => 4,
       "optional"   => "optional",
       "readonly"   => "readonly",
       "writeonce"  => "writeonce",
       "recursive"  => {
-        "_type"      => "Model",
-        "_version"   => 1,
+        '$type'      => "Model",
+        '$version'   => 1,
         "simple"     => "child",
         "overridden" => nil,
         "optional"   => nil,


### PR DESCRIPTION
To resolve conflict with ElasticSearch metadata.