### PR TITLE
VM:R Array `using` attributes

### DIFF
--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -17,7 +17,7 @@ class ViewModel::ActiveRecord < ViewModel::Record
   BEFORE_ATTRIBUTE       = "before"
   AFTER_ATTRIBUTE        = "after"
 
-  require 'view_model/active_record/collections'
+  require 'view_model/utils/collections'
   require 'view_model/active_record/association_data'
   require 'view_model/active_record/update_data'
   require 'view_model/active_record/update_context'

--- a/lib/view_model/active_record/update_data.rb
+++ b/lib/view_model/active_record/update_data.rb
@@ -2,7 +2,7 @@ require 'renum'
 require 'view_model/schemas'
 
 class ViewModel::ActiveRecord
-  using Collections
+  using ViewModel::Utils::Collections
 
   class FunctionalUpdate
     def self.for_type(type)

--- a/lib/view_model/active_record/update_operation.rb
+++ b/lib/view_model/active_record/update_operation.rb
@@ -2,7 +2,7 @@ require "renum"
 
 # Partially parsed tree of user-specified update hashes, created during deserialization.
 class ViewModel::ActiveRecord
-  using Collections
+  using ViewModel::Utils::Collections
 
   class UpdateOperation
     # inverse association and record to update a change in parent from a child

--- a/lib/view_model/changes.rb
+++ b/lib/view_model/changes.rb
@@ -1,4 +1,7 @@
+require "view_model/utils/collections"
 class ViewModel::Changes
+  using ViewModel::Utils::Collections
+
   attr_reader :new, :changed_attributes, :changed_associations, :deleted
 
   alias new? new
@@ -16,4 +19,15 @@ class ViewModel::Changes
       changed_associations.all? { |assoc| associations.include?(assoc.to_s) } &&
       changed_attributes.all? { |attr| attributes.include?(attr.to_s) }
   end
+
+  def ==(other)
+    return false unless other.is_a?(ViewModel::Changes)
+
+    self.new? == other.new? &&
+      self.changed_attributes.contains_exactly?(other.changed_attributes) &&
+      self.changed_associations.contains_exactly?(other.changed_associations) &&
+      self.deleted? == other.deleted?
+  end
+
+  alias eql? ==
 end

--- a/lib/view_model/record.rb
+++ b/lib/view_model/record.rb
@@ -37,8 +37,8 @@ class ViewModel::Record < ViewModel
     end
 
     # Specifies an attribute from the model to be serialized in this view
-    def attribute(attr, read_only: false, write_once: false, using: nil, optional: false)
-      attr_data = AttributeData.new(attr, using, optional, read_only, write_once)
+    def attribute(attr, read_only: false, write_once: false, using: nil, array: false, optional: false)
+      attr_data = AttributeData.new(attr, using, array, optional, read_only, write_once)
       _members[attr.to_s] = attr_data
 
       @generated_accessor_module.module_eval do
@@ -213,8 +213,8 @@ class ViewModel::Record < ViewModel
 
   def changes
     ViewModel::Changes.new(
-      new:                new_model?,
-      changed_attributes: changed_attributes)
+      new:                  new_model?,
+      changed_attributes:   changed_attributes)
   end
 
   def clear_changes!
@@ -241,13 +241,18 @@ class ViewModel::Record < ViewModel
   def _get_attribute(attr_data)
     attr = attr_data.name
 
-    val = model.public_send(attr)
+    value = model.public_send(attr)
 
-    if attr_data.using_viewmodel? && !val.nil?
-      val = attr_data.attribute_viewmodel.new(val)
+    if attr_data.using_viewmodel? && !value.nil?
+      vm_type = attr_data.attribute_viewmodel
+      if attr_data.array?
+        value = value.map { |v| vm_type.new(v) }
+      else
+        value = vm_type.new(value)
+      end
     end
 
-    val
+    value
   end
 
   def _serialize_attribute(attr_data, json, serialize_context:)
@@ -261,24 +266,36 @@ class ViewModel::Record < ViewModel
     end
   end
 
-  def _deserialize_attribute(attr_data, value, references:, deserialize_context:)
+  def _deserialize_attribute(attr_data, serialized_value, references:, deserialize_context:)
     attr = attr_data.name
 
-    if attr_data.using_viewmodel? && !value.nil?
-      value = attr_data.attribute_viewmodel.deserialize_from_view(value, references: references, deserialize_context: deserialize_context.for_child(self))
+    if attr_data.using_viewmodel? && !serialized_value.nil?
+      vm_type = attr_data.attribute_viewmodel
+      ctx = deserialize_context.for_child(self)
+      if attr_data.array?
+        value = serialized_value.map { |v| vm_type.deserialize_from_view(v, references: references, deserialize_context: ctx) }
+      else
+        value = vm_type.deserialize_from_view(serialized_value, references: references, deserialize_context: ctx)
+      end
+    else
+      value = serialized_value
     end
 
-    # Detect changes with ==. In the case of `using_viewmodel?`, this compares viewmodels.
+    # Detect changes with ==. In the case of `using_viewmodel?`, this compares viewmodels or arrays of viewmodels.
     if value != self.public_send(attr)
-      if attr_data.read_only? && !(attr_data.write_once? && model.new_record?)
+      if attr_data.read_only? && !(attr_data.write_once? && new_model?)
         raise ViewModel::DeserializationError.new("Cannot edit read only attribute: #{attr}", self.blame_reference)
       end
 
       attribute_changed!(attr)
 
       if attr_data.using_viewmodel? && !value.nil?
-        # Extract model from target viewmodel to save
-        value = value.model
+        # Extract model from target viewmodel to attach to model
+        if attr_data.array?
+          value = value.map(&:model)
+        else
+          value = value.model
+        end
       end
 
       model.public_send("#{attr}=", value)

--- a/lib/view_model/record/attribute_data.rb
+++ b/lib/view_model/record/attribute_data.rb
@@ -1,12 +1,17 @@
 class ViewModel::Record::AttributeData
   attr_reader :name, :attribute_viewmodel
 
-  def initialize(name, attribute_viewmodel, optional, read_only, write_once)
-    @name = name
+  def initialize(name, attribute_viewmodel, array, optional, read_only, write_once)
+    @name                = name
     @attribute_viewmodel = attribute_viewmodel
-    @optional = optional
-    @read_only = read_only
-    @write_once = write_once
+    @array               = array
+    @optional            = optional
+    @read_only           = read_only
+    @write_once          = write_once
+  end
+
+  def array?
+    @array
   end
 
   def optional?

--- a/lib/view_model/utils/collections.rb
+++ b/lib/view_model/utils/collections.rb
@@ -61,7 +61,9 @@ class ViewModel::Utils
       end
 
       def map_keys(&block)
-        dup.map_keys!(&block)
+        each_with_object({}) do |(k, v), new|
+          new[yield(k)] = v
+        end
       end
     end
   end

--- a/lib/view_model/utils/collections.rb
+++ b/lib/view_model/utils/collections.rb
@@ -1,4 +1,4 @@
-class ViewModel::ActiveRecord
+class ViewModel::Utils
   module Collections
     def self.count_by(enumerable)
       enumerable.each_with_object(Hash.new(0)) do |el, counts|
@@ -8,6 +8,12 @@ class ViewModel::ActiveRecord
     end
 
     refine Array do
+      def contains_exactly?(other)
+        vals = to_set
+        other.each { |o| return false unless vals.delete?(o) }
+        vals.blank?
+      end
+
       def count_by(&by)
         Collections::count_by(self, &by)
       end
@@ -32,6 +38,30 @@ class ViewModel::ActiveRecord
 
       def duplicates
         duplicates_by { |x| x }
+      end
+
+      def map_values!
+        self.keys.each do |k|
+          self[k] = yield(self[k])
+        end
+        self
+      end
+
+      def map_values(&block)
+        dup.map_values!(&block)
+      end
+
+      def map_keys!
+        self.keys.each do |k|
+          value = self.delete(k)
+          new_key = yield(k)
+          self[new_key] = value
+        end
+        self
+      end
+
+      def map_keys(&block)
+        dup.map_keys!(&block)
       end
     end
   end

--- a/test/unit/view_model/record_test.rb
+++ b/test/unit/view_model/record_test.rb
@@ -425,6 +425,15 @@ class ViewModel::RecordTest < ActiveSupport::TestCase
       include CanDeserializeToNew
       include CanDeserializeToExisting
 
+      it "rejects change to attribute" do
+        new_view = default_view.merge("nested" => "terrible")
+        ex = assert_raises(ViewModel::DeserializationError) do
+          viewmodel_class.deserialize_from_view(new_view, deserialize_context: update_context)
+        end
+
+        assert_match(/Expected 'nested' to be 'Array'/, ex.message)
+      end
+
       it "can edit a nested value" do
         default_view["nested"][0]["member"] = "changed"
         vm = viewmodel_class.deserialize_from_view(default_view, deserialize_context: update_context)

--- a/test/unit/view_model/record_test.rb
+++ b/test/unit/view_model/record_test.rb
@@ -7,74 +7,44 @@ require "view_model"
 require "view_model/record"
 
 class ViewModel::RecordTest < ActiveSupport::TestCase
+  using ViewModel::Utils::Collections
+  extend Minitest::Spec::DSL
 
-  Model = Struct.new(:simple, :overridden, :readonly, :writeonce, :recursive, :optional) do
-    def new_record?
-      writeonce.nil?
+  class TestDeserializeContext < ViewModel::DeserializeContext
+    class SharedContext < ViewModel::DeserializeContext::SharedContext
+      attr_reader :targets
+      def initialize(targets: [], **rest)
+        super(**rest)
+        @targets = targets
+      end
+    end
+
+    def self.shared_context_class
+      SharedContext
+    end
+
+    delegate :targets, to: :shared_context
+
+    def initialize(**rest)
+      super(**rest)
     end
   end
 
-  class ModelView < ViewModel::Record
-    self.model_class = Model
-    self.view_name = "Model"
-
-    attribute :simple
-    attribute :overridden
-    attribute :readonly,  read_only: true
-    attribute :writeonce, read_only: true, write_once: true
-    attribute :recursive, using: ModelView
-    attribute :optional,  optional: true
-
-    def serialize_overridden(json, serialize_context:)
-      json.overridden model.overridden.try { |o| o * 2 }
+  class TestSerializeContext < ViewModel::SerializeContext
+    def initialize(**rest)
+      super(**rest)
     end
+  end
 
-    def deserialize_overridden(value, references:, deserialize_context:)
-      before_value = model.overridden
-      model.overridden = value.try { |v| Integer(v) / 2 }
-      attribute_changed!(:overridden) unless before_value == model.overridden
-    end
-
-    def validate!
-      if simple == "naughty"
-        raise ViewModel::DeserializationError::Validation.new(
-                "Validation failed: simple was naughty",
-                self.blame_reference)
-      end
-    end
-
-    class DeserializeContext < ViewModel::DeserializeContext
-      class SharedContext < ViewModel::DeserializeContext::SharedContext
-        attr_reader :targets
-        def initialize(targets: [], **rest)
-          super(**rest)
-          @targets = targets
-        end
-      end
-
-      def self.shared_context_class
-        SharedContext
-      end
-
-      delegate :targets, to: :shared_context
-
-      def initialize(**rest)
-        super(**rest)
-      end
-    end
+  class TestViewModel < ViewModel::Record
+    self.unregistered = true
 
     def self.deserialize_context_class
-      DeserializeContext
-    end
-
-    class SerializeContext < ViewModel::SerializeContext
-      def initialize(**rest)
-        super(**rest)
-      end
+      TestDeserializeContext
     end
 
     def self.serialize_context_class
-      SerializeContext
+      TestSerializeContext
     end
 
     def self.resolve_viewmodel(type, version, id, new, view_hash, deserialize_context:)
@@ -86,184 +56,405 @@ class ViewModel::RecordTest < ActiveSupport::TestCase
     end
   end
 
-  def setup
-    @model = Model.new("simple", 2, "readonly", "writeonce", Model.new("child"), "optional")
+  describe 'VM::Record' do
+    let(:attributes)     { {} }
+    let(:model_body)     { nil }
+    let(:viewmodel_body) { nil }
 
-    @minimal_view = {
-      "_type"    => "Model",
-      "_version" => 1,
-    }
+    let(:model_class) do
+      mb = model_body
+      Struct.new(*attributes.keys) do
+        class_eval(&mb) if mb
+      end
+    end
 
-    @view = {
-      "_type"      => "Model",
-      "_version"   => 1,
-      "simple"     => "simple",
-      "overridden" => 4,
-      "optional"   => "optional",
-      "readonly"   => "readonly",
-      "writeonce"  => "writeonce",
-      "recursive"  => {
+    let(:viewmodel_class) do
+      mc    = model_class
+      attrs = attributes
+      vmb   = viewmodel_body
+      Class.new(TestViewModel) do
+        self.view_name   = "Model"
+        self.model_class = mc
+
+        attrs.each { |a, opts| attribute(a, **opts) }
+
+        class_eval(&vmb) if vmb
+      end
+    end
+
+    let(:view_base) do
+      {
         "_type"      => "Model",
-        "_version"   => 1,
-        "simple"     => "child",
-        "overridden" => nil,
-        "optional"   => nil,
-        "readonly"   => nil,
-        "writeonce"  => nil,
-        "recursive"  => nil
+        "_version"   => 1
       }
-    }
-  end
-
-  def test_create_from_view
-    @model.readonly = nil
-    @view.delete("readonly")
-
-    v = ModelView.deserialize_from_view(@view)
-    m = v.model
-
-    assert_equal(@model, m)
-  end
-
-  def test_create_bad_attribute
-    @view["bad"] = 6
-    ex = assert_raises(ViewModel::DeserializationError) do
-      ModelView.deserialize_from_view(@view)
     end
-    assert_match(/Illegal attribute/, ex.message)
-  end
 
-  def test_validation_failure_on_create
-    @view["simple"] = "naughty"
-    @view.delete("readonly")
-    ex = assert_raises(ViewModel::DeserializationError::Validation) do
-      ModelView.deserialize_from_view(@view)
+    let(:default_values) { {} }
+    let(:default_view_values) { default_values }
+    let(:default_model_values) { default_values }
+
+    let(:default_view) do
+      attributes.keys.each_with_object(view_base.dup) do |attr_name, view|
+        view[attr_name.to_s] = default_view_values.fetch(attr_name, attr_name.to_s)
+      end
     end
-    assert_match(/Validation failed: simple was naughty/, ex.message)
-  end
 
-  def test_update_from_view
+    let(:default_model) do
+      attr_values = attributes.keys.map do |attr_name|
+        default_model_values.fetch(attr_name, attr_name.to_s)
+      end
+      model_class.new(*attr_values)
+    end
+
+    let(:access_control) { TestAccessControl.new(true, true, true) }
+
+    let(:create_context) { TestDeserializeContext.new(access_control: access_control) }
+
     # Prime our simplistic `resolve_viewmodel` with the desired models to update
-    ctx = ModelView::DeserializeContext.new(targets: [@model, @model.recursive])
+    let(:update_context) { TestDeserializeContext.new(targets: [default_model], access_control: access_control) }
 
-    @view["simple"] = "change"
-    @view["recursive"]["simple"] = "morechange"
-
-    v = ModelView.deserialize_from_view(@view, deserialize_context: ctx)
-
-    assert_equal(@model, v.model)
-    assert_equal("change", @model.simple)
-    assert_equal("morechange", @model.recursive.simple)
-  end
-
-  def test_validation_failure_on_update
-    ctx = ModelView::DeserializeContext.new(targets: [@model, @model.recursive])
-    @view["simple"] = "naughty"
-
-    ex = assert_raises(ViewModel::DeserializationError::Validation) do
-      ModelView.deserialize_from_view(@view, deserialize_context: ctx)
-    end
-    assert_match(/Validation failed: simple was naughty/, ex.message)
-  end
-
-  def test_update_read_only
-    # Prime our simplistic `resolve_viewmodel` with the desired models to update
-    ctx = ModelView::DeserializeContext.new(targets: [@model, @model.recursive])
-
-    @view["readonly"] = "change"
-    ex = assert_raises(ViewModel::DeserializationError) do
-      ModelView.deserialize_from_view(@view, deserialize_context: ctx)
+    def assert_edited(vm, **changes)
+      ref = vm.to_reference
+      assert(access_control.visible_checks.include?(ref))
+      assert(access_control.editable_checks.include?(ref))
+      assert_equal([ViewModel::Changes.new(**changes)],
+                   access_control.all_valid_edit_changes(ref))
     end
 
-    assert_match(/Cannot edit read only/, ex.message)
-  end
-
-  def test_update_write_once
-    # Prime our simplistic `resolve_viewmodel` with the desired models to update
-    ctx = ModelView::DeserializeContext.new(targets: [@model, @model.recursive])
-
-    @view["writeonce"] = "change"
-    ex = assert_raises(ViewModel::DeserializationError) do
-      ModelView.deserialize_from_view(@view, deserialize_context: ctx)
+    def assert_unchanged(vm)
+      ref = vm.to_reference
+      assert(access_control.visible_checks.include?(ref))
+      assert(access_control.editable_checks.include?(ref))
+      assert_equal([], access_control.all_valid_edit_changes(ref))
     end
 
-    assert_match(/Cannot edit read only/, ex.message)
+    module CanDeserializeToNew
+      def self.included(base)
+        base.instance_eval do
+          it "can deserialize to a new model" do
+            vm = viewmodel_class.deserialize_from_view(default_view, deserialize_context: create_context)
+            assert_equal(default_model, vm.model)
+            refute(default_model.equal?(vm.model))
+
+            assert_edited(vm, new: true, changed_attributes: attributes.keys)
+          end
+        end
+      end
+    end
+
+    module CanDeserializeToExisting
+      def self.included(base)
+        base.instance_eval do
+          it "can deserialize to existing model with no changes" do
+            vm = viewmodel_class.deserialize_from_view(default_view, deserialize_context: update_context)
+            assert(default_model.equal?(vm.model))
+
+            assert_unchanged(vm)
+          end
+        end
+      end
+    end
+
+    module CanSerialize
+      def self.included(base)
+        base.instance_eval do
+          it "can serialize to the expected view" do
+            h = viewmodel_class.new(default_model).to_hash
+            assert_equal(default_view, h)
+          end
+        end
+      end
+    end
+
+    describe "with simple attribute" do
+      let(:attributes) { { simple: {} } }
+      include CanSerialize
+      include CanDeserializeToNew
+      include CanDeserializeToExisting
+
+      it "can be updated" do
+        new_view = default_view.merge("simple" => "changed")
+
+        vm = viewmodel_class.deserialize_from_view(new_view, deserialize_context: update_context)
+
+        assert(default_model.equal?(vm.model), "returned model was not the same")
+        assert_equal("changed", default_model.simple)
+        assert_edited(vm, changed_attributes: [:simple])
+      end
+
+      it "rejects unknown attributes" do
+        view = default_view.merge("unknown" => "illegal")
+        ex = assert_raises(ViewModel::DeserializationError) do
+          viewmodel_class.deserialize_from_view(view, deserialize_context: create_context)
+        end
+        assert_match(/Illegal attribute/, ex.message)
+      end
+
+      it "can prune an attribute" do
+        h = viewmodel_class.new(default_model).to_hash(serialize_context: TestSerializeContext.new(prune: [:simple]))
+        pruned_view = default_view.tap { |v| v.delete("simple") }
+        assert_equal(pruned_view, h)
+      end
+
+      it "edit checks when creating empty" do
+        vm = viewmodel_class.deserialize_from_view(view_base, deserialize_context: create_context)
+        refute(default_model.equal?(vm.model), "returned model was the same")
+        assert_edited(vm, new: true)
+      end
+    end
+
+    describe "with validated simple attribute" do
+      let(:attributes) { { validated: {} } }
+      let(:viewmodel_body) do
+        ->(x) do
+          def validate!
+            if validated == "naughty"
+              raise ViewModel::DeserializationError::Validation.new(
+                      "Validation failed: validated was naughty",
+                      self.blame_reference)
+            end
+          end
+        end
+      end
+
+      include CanSerialize
+      include CanDeserializeToNew
+      include CanDeserializeToExisting
+
+      it "rejects update when validation fails" do
+        new_view = default_view.merge("validated" => "naughty")
+
+        ex = assert_raises(ViewModel::DeserializationError::Validation) do
+          viewmodel_class.deserialize_from_view(new_view, deserialize_context: update_context)
+        end
+
+        assert_match(/Validation failed: validated was naughty/, ex.message)
+      end
+    end
+
+    describe "with read-only attribute" do
+      let(:attributes) { { read_only: { read_only: true } } }
+
+      include CanSerialize
+      include CanDeserializeToExisting
+
+      it "deserializes to new without the attribute" do
+        new_view = default_view.tap { |v| v.delete("read_only") }
+        vm = viewmodel_class.deserialize_from_view(new_view, deserialize_context: create_context)
+        refute(default_model.equal?(vm.model))
+        assert_nil(vm.model.read_only)
+        assert_edited(vm, new: true)
+      end
+
+      it "rejects deserialize from new" do
+        ex = assert_raises(ViewModel::DeserializationError) do
+          viewmodel_class.deserialize_from_view(default_view, deserialize_context: create_context)
+        end
+        assert_match(/Cannot edit read only/, ex.message)
+      end
+
+      it "rejects update if changed" do
+        new_view = default_view.merge("read_only" => "written")
+        ex = assert_raises(ViewModel::DeserializationError) do
+          viewmodel_class.deserialize_from_view(new_view, deserialize_context: update_context)
+        end
+
+        assert_match(/Cannot edit read only/, ex.message)
+      end
+    end
+
+    describe "with read-only write-once attribute" do
+      let(:attributes) { { write_once: { read_only: true, write_once: true } } }
+      let(:model_body) do
+        ->(x) do
+          # For the purposes of testing, we assume a record is new and can be
+          # written once to if write_once is nil. We will never write a nil.
+          def new_record?
+            write_once.nil?
+          end
+        end
+      end
+
+      include CanSerialize
+      include CanDeserializeToNew
+      include CanDeserializeToExisting
+
+      it "rejects change to attribute" do
+        new_view = default_view.merge("write_once" => "written")
+        ex = assert_raises(ViewModel::DeserializationError) do
+          viewmodel_class.deserialize_from_view(new_view, deserialize_context: update_context)
+        end
+
+        assert_match(/Cannot edit read only/, ex.message)
+      end
+    end
+
+    describe "with custom serialization" do
+      let(:attributes)           { { overridden: {} } }
+      let(:default_view_values)  { { overridden: 10 } }
+      let(:default_model_values) { { overridden: 5 } }
+      let(:viewmodel_body) do
+        ->(x) do
+          def serialize_overridden(json, serialize_context:)
+            json.overridden model.overridden.try { |o| o * 2 }
+          end
+
+          def deserialize_overridden(value, references:, deserialize_context:)
+            before_value = model.overridden
+            model.overridden = value.try { |v| Integer(v) / 2 }
+            attribute_changed!(:overridden) unless before_value == model.overridden
+          end
+        end
+      end
+
+      include CanSerialize
+      include CanDeserializeToNew
+      include CanDeserializeToExisting
+
+      it "can be updated" do
+        new_view = default_view.merge("overridden" => "20")
+
+        vm = viewmodel_class.deserialize_from_view(new_view, deserialize_context: update_context)
+
+        assert(default_model.equal?(vm.model), "returned model was not the same")
+        assert_equal(10, default_model.overridden)
+
+        assert_edited(vm, changed_attributes: [:overridden])
+      end
+    end
+
+    describe "with optional attributes" do
+      let(:attributes) { { optional: { optional: true } } }
+
+      include CanDeserializeToNew
+      include CanDeserializeToExisting
+
+      it "can serialize with the optional attribute" do
+        h = viewmodel_class.new(default_model).to_hash(serialize_context: TestSerializeContext.new(include: [:optional]))
+        assert_equal(default_view, h)
+      end
+
+      it "can serialize without the optional attribute" do
+        h = viewmodel_class.new(default_model).to_hash
+        pruned_view = default_view.tap { |v| v.delete("optional") }
+        assert_equal(pruned_view, h)
+      end
+    end
+
+    Nested = Struct.new(:member)
+
+    class NestedView < TestViewModel
+      self.view_name = "Nested"
+      self.model_class = Nested
+      attribute :member
+    end
+
+    describe "with nested viewmodel" do
+      let(:default_nested_model) { Nested.new("member") }
+      let(:default_nested_view)  { view_base.merge("_type" => "Nested", "member" => "member") }
+
+      let(:attributes) {{ simple: {}, nested: { using: NestedView } }}
+
+      let(:default_view_values)  { { nested: default_nested_view } }
+      let(:default_model_values) { { nested: default_nested_model } }
+
+      let(:update_context) { TestDeserializeContext.new(targets: [default_model, default_nested_model],
+                                                        access_control: access_control) }
+
+      include CanSerialize
+      include CanDeserializeToNew
+      include CanDeserializeToExisting
+
+      it "can update the nested value" do
+        new_view = default_view.merge("nested" => default_nested_view.merge("member" => "changed"))
+
+        vm = viewmodel_class.deserialize_from_view(new_view, deserialize_context: update_context)
+
+        assert(default_model.equal?(vm.model), "returned model was not the same")
+        assert(default_nested_model.equal?(vm.model.nested), "returned nested model was not the same")
+
+        assert_equal("changed", default_model.nested.member)
+
+        assert_unchanged(vm)
+        assert_edited(vm.nested, changed_attributes: [:member])
+      end
+
+      it "can replace the nested value" do
+        # The value will be unified if it is different after deserialization
+        new_view = default_view.merge("nested" => default_nested_view.merge("member" => "changed"))
+
+        partial_update_context = TestDeserializeContext.new(targets: [default_model],
+                                                            access_control: access_control)
+
+        vm = viewmodel_class.deserialize_from_view(new_view, deserialize_context: partial_update_context)
+
+        assert(default_model.equal?(vm.model), "returned model was not the same")
+        refute(default_nested_model.equal?(vm.model.nested), "returned nested model was the same")
+
+        assert_edited(vm, new: false, changed_attributes: [:nested])
+        assert_edited(vm.nested, new: true, changed_attributes: [:member])
+      end
+
+      it "can prune attributes in the nested value" do
+        h = viewmodel_class.new(default_model).to_hash(
+          serialize_context: TestSerializeContext.new(prune: { nested: [:member] }))
+
+        pruned_view = default_view.tap { |v| v["nested"].delete("member") }
+        assert_equal(pruned_view, h)
+      end
+    end
+
+    describe "with array of nested viewmodel" do
+      let(:default_nested_model_1) { Nested.new("member1") }
+      let(:default_nested_view_1)  { view_base.merge("_type" => "Nested", "member" => "member1") }
+
+      let(:default_nested_model_2) { Nested.new("member2") }
+      let(:default_nested_view_2)  { view_base.merge("_type" => "Nested", "member" => "member2") }
+
+      let(:attributes) {{ simple: {}, nested: { using: NestedView, array: true } }}
+
+      let(:default_view_values)  { { nested: [default_nested_view_1, default_nested_view_2] } }
+      let(:default_model_values) { { nested: [default_nested_model_1, default_nested_model_2] } }
+
+      let(:update_context) {
+        TestDeserializeContext.new(targets: [default_model, default_nested_model_1, default_nested_model_2],
+                                   access_control: access_control)
+      }
+
+      include CanSerialize
+      include CanDeserializeToNew
+      include CanDeserializeToExisting
+
+      it "can edit a nested value" do
+        default_view["nested"][0]["member"] = "changed"
+        vm = viewmodel_class.deserialize_from_view(default_view, deserialize_context: update_context)
+        assert(default_model.equal?(vm.model), "returned model was not the same")
+        assert_equal(2, vm.model.nested.size)
+        assert(default_nested_model_1.equal?(vm.model.nested[0]))
+        assert(default_nested_model_2.equal?(vm.model.nested[1]))
+
+        assert_unchanged(vm)
+        assert_edited(vm.nested[0], changed_attributes: [:member])
+      end
+
+      it "can append a nested value" do
+        default_view["nested"] << view_base.merge("_type" => "Nested", "member" => "member3")
+
+        vm = viewmodel_class.deserialize_from_view(default_view, deserialize_context: update_context)
+
+        assert(default_model.equal?(vm.model), "returned model was not the same")
+        assert_equal(3, vm.model.nested.size)
+        assert(default_nested_model_1.equal?(vm.model.nested[0]))
+        assert(default_nested_model_2.equal?(vm.model.nested[1]))
+
+        vm.model.nested.each_with_index do |nvm, i|
+          assert_equal("member#{i+1}", nvm.member)
+        end
+
+        assert_edited(vm, changed_attributes: [:nested])
+        assert_edited(vm.nested[2], new: true, changed_attributes: [:member])
+      end
+    end
   end
 
-  def test_serialize_view
-    h = ModelView.new(@model).to_hash(serialize_context: ModelView::SerializeContext.new(include: [:optional, { recursive: :optional }]))
-    assert_equal(@view, h)
-
-    @view["recursive"].delete("optional")
-    h = ModelView.new(@model).to_hash(serialize_context: ModelView::SerializeContext.new(include: [:optional]))
-    assert_equal(@view, h)
-
-    @view.delete("optional")
-    h = ModelView.new(@model).to_hash
-    assert_equal(@view, h)
-  end
-
-  def test_serialize_with_prune
-    ['simple',     'optional'].each { |k| @view.delete(k) }
-    ['overridden', 'optional'].each { |k| @view["recursive"].delete(k) }
-
-    h = ModelView.new(@model).to_hash(serialize_context: ModelView::SerializeContext.new(prune: [:simple, { recursive: :overridden }]))
-    assert_equal(@view, h)
-  end
-
-  def test_edit_check_no_changes
-    ref            = ViewModel::Reference.new(ModelView, nil)
-    access_control = TestAccessControl.new(true, true, true)
-
-    context = ModelView::DeserializeContext.new(
-      targets:        [@model, @model.recursive],
-      access_control: access_control)
-
-    ModelView.deserialize_from_view(@view, deserialize_context: context)
-
-    assert_empty(access_control.all_valid_edit_changes(ref))
-  end
-
-  def test_edit_check # shotgun test of various concerns
-    ref            = ViewModel::Reference.new(ModelView, nil)
-    access_control = TestAccessControl.new(true, true, true)
-
-    @model.recursive    = nil
-
-    @view["simple"]     = "outer simple changed"
-    @view["overridden"] = @view["overridden"] + 42
-
-    context = ModelView::DeserializeContext.new(
-      targets:        [@model],
-      access_control: access_control)
-
-    ModelView.deserialize_from_view(@view, deserialize_context: context)
-
-    all_changes = access_control.all_valid_edit_changes(ref)
-    assert_equal(2, all_changes.length)
-
-    ((inner_changes,), (outer_changes,)) = all_changes.partition { |c| c.new? }
-
-    assert_equal(false, outer_changes.new?)
-    assert_equal(false, outer_changes.deleted?)
-    assert_equal(%w(simple overridden recursive),
-                 outer_changes.changed_attributes)
-    assert_empty(outer_changes.changed_associations)
-
-    assert_equal(true, inner_changes.new?)
-    assert_equal(false, inner_changes.deleted?)
-    assert_equal(%w(simple),
-                 inner_changes.changed_attributes)
-    assert_empty(inner_changes.changed_associations)
-  end
-
-  def test_edit_check_on_create_empty
-    access_control = TestAccessControl.new(true, true, true)
-    context        = ModelView::DeserializeContext.new(access_control: access_control)
-
-    ModelView.deserialize_from_view(@minimal_view, deserialize_context: context)
-
-    assert_equal([ViewModel::Reference.new(ModelView, nil)],
-                 access_control.valid_edit_refs)
-  end
 end


### PR DESCRIPTION
`attribute .. using: x` allows us to delegate (de)serialization of an attribute to another viewmodel.
It would be nice to also support arrays of other viewmodels.