### PR TITLE
Alias registration

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,3 +1,3 @@
 module IknowViewModels
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -10,6 +10,10 @@ class ViewModel
   VERSION_ATTRIBUTE   = "_version"
   NEW_ATTRIBUTE       = "_new"
 
+  Metadata = Struct.new(:id, :view_name, :schema_version, :new) do
+    alias :new? :new
+  end
+
   class << self
     attr_accessor :_attributes
     attr_accessor :schema_version
@@ -22,7 +26,6 @@ class ViewModel
     def initialize_as_viewmodel
       @_attributes    = []
       @schema_version = 1
-      @debug_name     = nil
       @view_aliases   = []
     end
 
@@ -46,14 +49,6 @@ class ViewModel
 
     def add_view_alias(as)
       view_aliases << as
-    end
-
-    def debug_name=(name)
-      @debug_name = name
-    end
-
-    def debug_name
-      @debug_name || view_name
     end
 
     # ViewModels are typically going to be pretty simple structures. Make it a
@@ -89,14 +84,16 @@ class ViewModel
       type_name      = hash.delete(ViewModel::TYPE_ATTRIBUTE)
       schema_version = hash.delete(ViewModel::VERSION_ATTRIBUTE)
       new            = hash.delete(ViewModel::NEW_ATTRIBUTE) { false }
-      return type_name, schema_version, id, new
+
+      Metadata.new(id, type_name, schema_version, new)
     end
 
     def extract_reference_only_metadata(hash)
       ViewModel::Schemas.verify_schema!(ViewModel::Schemas::VIEWMODEL_UPDATE, hash)
       id             = hash.delete(ViewModel::ID_ATTRIBUTE)
       type_name      = hash.delete(ViewModel::TYPE_ATTRIBUTE)
-      return type_name, id
+
+      Metadata.new(id, type_name, nil, false)
     end
 
     def extract_reference_metadata(hash)

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -43,12 +43,9 @@ class ViewModel
       @view_name = name
     end
 
-    def view_names
-      [view_name, *view_aliases]
-    end
-
     def add_view_alias(as)
       view_aliases << as
+      ViewModel::Registry.register(self, as: as)
     end
 
     # ViewModels are typically going to be pretty simple structures. Make it a

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -13,6 +13,7 @@ class ViewModel
   class << self
     attr_accessor :_attributes
     attr_accessor :schema_version
+    attr_reader   :view_aliases
 
     def inherited(subclass)
       subclass.initialize_as_viewmodel
@@ -22,6 +23,7 @@ class ViewModel
       @_attributes    = []
       @schema_version = 1
       @debug_name     = nil
+      @view_aliases   = []
     end
 
     def view_name
@@ -36,6 +38,14 @@ class ViewModel
 
     def view_name=(name)
       @view_name = name
+    end
+
+    def view_names
+      [view_name, *view_aliases]
+    end
+
+    def add_view_alias(as)
+      view_aliases << as
     end
 
     def debug_name=(name)
@@ -215,6 +225,12 @@ class ViewModel
 
   def to_reference
     ViewModel::Reference.new(self.class, self.id)
+  end
+
+  # Delegate view_name to class in most cases. Polymorphic views may wish to
+  # override this to select a specific alias.
+  def view_name
+    self.class.view_name
   end
 
   # When deserializing, if an error occurs within this viewmodel, what viewmodel

--- a/lib/view_model/active_record/association_data.rb
+++ b/lib/view_model/active_record/association_data.rb
@@ -142,7 +142,7 @@ class ViewModel::ActiveRecord::AssociationData
       Class.new(ViewModel::ActiveRecord) do
         self.synthetic = true
         self.model_class = direct_reflection.klass
-        self.debug_name = direct_reflection.klass.name
+        self.view_name = direct_reflection.klass.name
         association indirect_reflection.name, shared: true, optional: false, viewmodels: viewmodel_classes
         acts_as_list through_order_attr if through_order_attr
       end

--- a/lib/view_model/active_record/association_manipulation.rb
+++ b/lib/view_model/active_record/association_manipulation.rb
@@ -248,9 +248,15 @@ module AssociationManipulation
     direct_update_data = indirect_references.map do |ref_name, update|
       existing_id = existing_direct_ids[update.id] unless update.new?
 
-      UpdateData.new(direct_viewmodel_class, existing_id, existing_id.nil?,
+      metadata = ViewModel::Metadata.new(existing_id,
+                                         direct_viewmodel_class.view_name,
+                                         direct_viewmodel_class.schema_version,
+                                         existing_id.nil?)
+
+      UpdateData.new(direct_viewmodel_class,
+                     metadata,
                      { indirect_reflection.name.to_s => { ViewModel::REFERENCE_ATTRIBUTE => ref_name }},
-                     [ref_name] )
+                     [ref_name])
     end
 
     return direct_update_data, referenced_update_data

--- a/lib/view_model/record.rb
+++ b/lib/view_model/record.rb
@@ -173,7 +173,7 @@ class ViewModel::Record < ViewModel
 
   def serialize_view(json, serialize_context: self.class.new_serialize_context)
     json.set!(ViewModel::ID_ATTRIBUTE, model.id) if model.respond_to?(:id)
-    json.set!(ViewModel::TYPE_ATTRIBUTE, self.class.view_name)
+    json.set!(ViewModel::TYPE_ATTRIBUTE, self.view_name)
     json.set!(ViewModel::VERSION_ATTRIBUTE, self.class.schema_version)
 
     serialize_members(json, serialize_context: serialize_context)

--- a/lib/view_model/record.rb
+++ b/lib/view_model/record.rb
@@ -59,22 +59,22 @@ class ViewModel::Record < ViewModel
     def deserialize_from_view(view_hashes, references: {}, deserialize_context: new_deserialize_context)
       ViewModel::Utils.map_one_or_many(view_hashes) do |view_hash|
         view_hash = view_hash.dup
-        type, version, id, new = ViewModel.extract_viewmodel_metadata(view_hash)
+        metadata = ViewModel.extract_viewmodel_metadata(view_hash)
 
-        if type != self.view_name
+        unless self.view_names.include?(metadata.view_name)
           raise ViewModel::DeserializationError.new(
-                  "Cannot deserialize type #{type}, expected #{self.view_name}.",
-                  ViewModel::Reference.new(self, id))
+                  "Cannot deserialize type #{metadata.view_name}, expected #{self.view_names}.",
+                  ViewModel::Reference.new(self, metadata.id))
         end
 
-        if version && !self.accepts_schema_version?(version)
+        if metadata.schema_version && !self.accepts_schema_version?(metadata.schema_version)
           raise ViewModel::DeserializationError::SchemaMismatch.new(
                   "Mismatched schema version for type #{self.view_name}, "\
-                  "expected #{self.schema_version}, received #{version}.",
-                  ViewModel::Reference.new(self, id))
+                  "expected #{self.schema_version}, received #{metadata.schema_version}.",
+                  ViewModel::Reference.new(self, metadata.id))
         end
 
-        viewmodel = resolve_viewmodel(type, version, id, new, view_hash, deserialize_context: deserialize_context)
+        viewmodel = resolve_viewmodel(metadata, view_hash, deserialize_context: deserialize_context)
 
         deserialize_members_from_view(viewmodel, view_hash, references: references, deserialize_context: deserialize_context)
 
@@ -111,7 +111,7 @@ class ViewModel::Record < ViewModel
       viewmodel.clear_changes!
     end
 
-    def resolve_viewmodel(type, version, id, new, view_hash, deserialize_context:)
+    def resolve_viewmodel(metadata, view_hash, deserialize_context:)
       self.for_new_model
     end
 

--- a/lib/view_model/record.rb
+++ b/lib/view_model/record.rb
@@ -61,9 +61,9 @@ class ViewModel::Record < ViewModel
         view_hash = view_hash.dup
         metadata = ViewModel.extract_viewmodel_metadata(view_hash)
 
-        unless self.view_names.include?(metadata.view_name)
+        unless self.view_name == metadata.view_name || self.view_aliases.include?(metadata.view_name)
           raise ViewModel::DeserializationError.new(
-                  "Cannot deserialize type #{metadata.view_name}, expected #{self.view_names}.",
+                  "Cannot deserialize type #{metadata.view_name}, expected #{[self.view_name, *self.view_aliases]}.",
                   ViewModel::Reference.new(self, metadata.id))
         end
 

--- a/lib/view_model/reference.rb
+++ b/lib/view_model/reference.rb
@@ -9,7 +9,7 @@ class ViewModel
     end
 
     def to_s
-      "'#{viewmodel_class.debug_name}(#{model_id})'"
+      "'#{viewmodel_class.view_name}(#{model_id})'"
     end
 
     def ==(other)

--- a/lib/view_model/registry.rb
+++ b/lib/view_model/registry.rb
@@ -16,7 +16,12 @@ class ViewModel::Registry
     # Resolve names for any deferred viewmodel classes
     until @deferred_viewmodel_classes.empty? do
       vm = @deferred_viewmodel_classes.pop
-      @viewmodel_classes_by_name[vm.view_name] = vm if vm.should_register?
+
+      if vm.should_register?
+        vm.view_names.each do |name|
+          @viewmodel_classes_by_name[name] = vm
+        end
+      end
     end
 
     viewmodel_class = @viewmodel_classes_by_name[name]

--- a/lib/view_model/registry.rb
+++ b/lib/view_model/registry.rb
@@ -15,12 +15,11 @@ class ViewModel::Registry
 
     # Resolve names for any deferred viewmodel classes
     until @deferred_viewmodel_classes.empty? do
-      vm = @deferred_viewmodel_classes.pop
+      vm, view_name = @deferred_viewmodel_classes.pop
 
       if vm.should_register?
-        vm.view_names.each do |name|
-          @viewmodel_classes_by_name[name] = vm
-        end
+        view_name ||= vm.view_name
+        @viewmodel_classes_by_name[view_name] = vm
       end
     end
 
@@ -33,7 +32,7 @@ class ViewModel::Registry
     viewmodel_class
   end
 
-  def register(viewmodel)
-    @deferred_viewmodel_classes << viewmodel
+  def register(viewmodel, as: nil)
+    @deferred_viewmodel_classes << [viewmodel, as]
   end
 end

--- a/lib/view_model/registry.rb
+++ b/lib/view_model/registry.rb
@@ -1,6 +1,8 @@
 class ViewModel::Registry
   include Singleton
 
+  DEFERRED_NAME = Object.new
+
   class << self
     delegate :for_view_name, :register, to: :instance
   end
@@ -18,7 +20,7 @@ class ViewModel::Registry
       vm, view_name = @deferred_viewmodel_classes.pop
 
       if vm.should_register?
-        view_name ||= vm.view_name
+        view_name = vm.view_name if view_name == DEFERRED_NAME
         @viewmodel_classes_by_name[view_name] = vm
       end
     end
@@ -32,7 +34,7 @@ class ViewModel::Registry
     viewmodel_class
   end
 
-  def register(viewmodel, as: nil)
+  def register(viewmodel, as: DEFERRED_NAME)
     @deferred_viewmodel_classes << [viewmodel, as]
   end
 end

--- a/test/unit/view_model/active_record/customization_test.rb
+++ b/test/unit/view_model/active_record/customization_test.rb
@@ -28,7 +28,7 @@ class ViewModel::ActiveRecord::SpecializeAssociationTest < ActiveSupport::TestCa
         attributes :text
         association :translations
 
-        def self.pre_parse_translations(viewmodel_reference, hash, translations)
+        def self.pre_parse_translations(viewmodel_reference, metadata, hash, translations)
           raise "type check" unless translations.is_a?(Hash) && translations.all? { |k, v| k.is_a?(String) && v.is_a?(String) }
           hash["translations"] = translations.map { |lang, text| { "_type" => "Translation", "language" => lang, "translation" => text } }
         end
@@ -188,7 +188,7 @@ class ViewModel::ActiveRecord::FlattenAssociationTest < ActiveSupport::TestCase
         attributes :name
         association :section_data, viewmodels: [VocabSectionView, QuizSectionView]
 
-        def self.pre_parse(viewmodel_reference, user_data)
+        def self.pre_parse(viewmodel_reference, metadata, user_data)
           section_type_name = user_data.delete("section_type")
           section_type = SectionType.with_name(section_type_name)
           raise "Invalid section type: #{section_type_name.inspect}" unless section_type

--- a/test/unit/view_model/record_test.rb
+++ b/test/unit/view_model/record_test.rb
@@ -47,7 +47,7 @@ class ViewModel::RecordTest < ActiveSupport::TestCase
       TestSerializeContext
     end
 
-    def self.resolve_viewmodel(type, version, id, new, view_hash, deserialize_context:)
+    def self.resolve_viewmodel(metadata, view_hash, deserialize_context:)
       if target_model = deserialize_context.targets.shift
         self.new(target_model)
       else


### PR DESCRIPTION
Allow aliases to viewmodels to be explicitly registered. Improve viewmodel metadata, provide to pre_parse and resolve_viewmodel.