### PR TITLE
Refactor viewmodel errors

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,3 +1,3 @@
 module IknowViewModels
-  VERSION = "2.2.0"
+  VERSION = "2.3.0"
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -147,7 +147,7 @@ class ViewModel
 
     # Rebuild this viewmodel from a serialized hash. Must be defined in subclasses.
     def deserialize_from_view(hash_data, references: {}, deserialize_context: new_deserialize_context)
-      raise DeserializationError.new("Deserialization not defined for '#{self.name}'", self.blame_reference)
+      raise DeserializationError::ReadOnlyType.new(blame_reference)
     end
 
     def serialize_context_class
@@ -263,3 +263,5 @@ require 'view_model/reference'
 require 'view_model/serialize_context'
 require 'view_model/deserialize_context'
 require 'view_model/changes'
+require 'view_model/schemas'
+require 'view_model/error_view'

--- a/lib/view_model/access_control/composed.rb
+++ b/lib/view_model/access_control/composed.rb
@@ -74,7 +74,7 @@ class ViewModel::AccessControl::Composed < ViewModel::AccessControl
       @reasons = reasons
     end
 
-    def metadata
+    def meta
       super.merge(conditions: @reasons.to_a)
     end
 

--- a/lib/view_model/access_control_error.rb
+++ b/lib/view_model/access_control_error.rb
@@ -1,20 +1,15 @@
 class ViewModel::AccessControlError < ViewModel::AbstractError
-  attr_reader :nodes
+  attr_reader :nodes, :detail
+  status 403
+  code "AccessControl.Forbidden"
 
   def initialize(detail, nodes = [])
-    super(detail)
+    @detail = detail
     @nodes = Array.wrap(nodes)
+    super()
   end
 
-  def status
-    403
-  end
-
-  def metadata
+  def meta
     blame_metadata(nodes)
-  end
-
-  def code
-    "AccessControl.Forbidden"
   end
 end

--- a/lib/view_model/access_control_error.rb
+++ b/lib/view_model/access_control_error.rb
@@ -1,15 +1,10 @@
-class ViewModel::AccessControlError < ViewModel::AbstractError
-  attr_reader :nodes, :detail
+class ViewModel::AccessControlError < ViewModel::AbstractErrorWithBlame
+  attr_reader :detail
   status 403
   code "AccessControl.Forbidden"
 
   def initialize(detail, nodes = [])
     @detail = detail
-    @nodes = Array.wrap(nodes)
-    super()
-  end
-
-  def meta
-    blame_metadata(nodes)
+    super(nodes)
   end
 end

--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -143,8 +143,7 @@ class ViewModel::ActiveRecord < ViewModel::Record
           missing_ids = ids - models.map(&:id)
           if missing_ids.present?
             raise ViewModel::DeserializationError::NotFound.new(
-                    "Couldn't find #{self.model_class.name}(s) with id(s)=#{missing_ids.inspect}",
-                    missing_ids.map { |id| ViewModel::Reference.new(self, id) } )
+                    missing_ids.map { |id| ViewModel::Reference.new(self, id) })
           end
         end
 

--- a/lib/view_model/active_record/association_manipulation.rb
+++ b/lib/view_model/active_record/association_manipulation.rb
@@ -129,7 +129,7 @@ module AssociationManipulation
           end
         end
 
-        updated_viewmodels = update_context.run!(deserialize_context: deserialize_context.for_child(self))
+        updated_viewmodels = update_context.run!(deserialize_context: deserialize_context.for_child(self, association_name: association_name))
 
         if association_data.through?
           updated_viewmodels.map! do |direct_vm|
@@ -196,7 +196,7 @@ module AssociationManipulation
                 blame_reference)
       end
 
-      child_context = deserialize_context.for_child(self)
+      child_context = deserialize_context.for_child(self, association_name: association_name)
       vm = direct_viewmodel.new(models.first)
       child_context.visible!(vm)
       initial_editability = child_context.initial_editability(vm)

--- a/lib/view_model/active_record/collection_nested_controller.rb
+++ b/lib/view_model/active_record/collection_nested_controller.rb
@@ -47,7 +47,7 @@ module ViewModel::ActiveRecord::CollectionNestedController
       after  = parse_relative_position(:after)
 
       if before && after
-        raise ViewModel::DeserializationError.new("Can not provide both `before` and `after` anchors for a collection append")
+        raise ViewModel::DeserializationError::InvalidSyntax.new("Can not provide both `before` and `after` anchors for a collection append")
       end
 
 
@@ -85,7 +85,7 @@ module ViewModel::ActiveRecord::CollectionNestedController
         type_name = parse_param("#{name}_type")
         type = association_data.viewmodel_class_for_name(type_name)
         if type.nil?
-          raise ViewModel::DeserializationError.new("Invalid '#{name}_type' for association: #{type_name}")
+          raise ViewModel::DeserializationError::InvalidAssociationType.new(association_data.association_name.to_s, type_name)
         end
       else
         type = owner_viewmodel.viewmodel_class

--- a/lib/view_model/active_record/update_operation.rb
+++ b/lib/view_model/active_record/update_operation.rb
@@ -50,11 +50,11 @@ class ViewModel::ActiveRecord
 
     # Evaluate a built update tree, applying and saving changes to the models.
     def run!(deserialize_context:)
-      raise "Not yet built!" unless built? # TODO
+      raise ViewModel::DeserializationError::Internal.new("Internal error: UpdateOperation run before build") unless built?
 
       case @run_state
       when RunState::Running
-        raise "Cycle! Bad!" # TODO
+        raise ViewModel::DeserializationError::Internal.new("Internal error: Cycle found in running UpdateOperation")
       when RunState::Run
         return viewmodel
       end
@@ -94,7 +94,8 @@ class ViewModel::ActiveRecord
         valid_members = viewmodel.class._members.keys.map(&:to_s).to_set
         bad_keys = attributes.keys.reject { |k| valid_members.include?(k) }
         if bad_keys.present?
-          raise_deserialization_error("Illegal attribute/association(s) #{bad_keys.inspect} for viewmodel #{viewmodel.class.view_name}")
+          causes = bad_keys.map { |k| ViewModel::DeserializationError::UnknownAttribute.new(k, blame_reference) }
+          raise ViewModel::DeserializationError::Collection.for_errors(causes)
         end
 
         attributes.each do |attr_name, serialized_value|
@@ -150,9 +151,9 @@ class ViewModel::ActiveRecord
         begin
           model.save!
         rescue ::ActiveRecord::RecordInvalid => ex
-          raise_deserialization_error(ex.message, model.errors.messages, error: ViewModel::DeserializationError::Validation)
+          raise ViewModel::DeserializationError::Validation.from_active_model(ex.errors, blame_reference)
         rescue ::ActiveRecord::StaleObjectError => ex
-          raise_deserialization_error(ex.message, error: ViewModel::DeserializationError::LockFailure)
+          raise ViewModel::DeserializationError::LockFailure.new(blame_reference)
         end
         debug "<- #{debug_name}: Saved"
 
@@ -203,12 +204,12 @@ class ViewModel::ActiveRecord
       @run_state = RunState::Run
       viewmodel
     rescue ::ActiveRecord::StatementInvalid, ::ActiveRecord::InvalidForeignKey, ::ActiveRecord::RecordNotSaved => ex
-      raise_deserialization_error(ex.message)
+      raise ViewModel::DeserializationError::DatabaseConstraint.new(ex.message, blame_reference)
     end
 
     # Recursively builds UpdateOperations for the associations in our UpdateData
     def build!(update_context)
-      raise "Cannot build deferred update" if deferred? # TODO
+      raise ViewModel::DeserializationError::Internal.new("Internal error: UpdateOperation cannot build a deferred update") if deferred?
       return self if built?
 
       update_data.associations.each do |association_name, association_update_data|
@@ -264,12 +265,14 @@ class ViewModel::ActiveRecord
         referred_update    = nil
         referred_viewmodel = nil
       else
-        referred_update    = update_context.resolve_reference(reference_string)
+        referred_update    = update_context.resolve_reference(reference_string, blame_reference)
         referred_viewmodel = referred_update.viewmodel
 
         unless association_data.accepts?(referred_viewmodel.class)
-          raise_deserialization_error("Type error: association '#{association_data.direct_reflection.name}'"\
-                                      " can't refer to #{referred_viewmodel.class}")
+          raise ViewModel::DeserializationError::InvalidAssociationType.new(
+            association_data.association_name.to_s,
+            referred_viewmodel.class.view_name,
+            blame_reference)
         end
 
         referred_update.build!(update_context)
@@ -440,9 +443,8 @@ class ViewModel::ActiveRecord
                 ref         = fupdate.before || fupdate.after
                 index       = child_datas.find_index { |cd| cd.viewmodel_reference == ref }
                 unless index
-                  raise ViewModel::DeserializationError::NotFound.new(
-                    "Attempted to insert relative to reference that does not exist #{ref}",
-                    [ref])
+                  raise ViewModel::DeserializationError::AssociatedNotFound.new(
+                    association_data.association_name.to_s, ref, blame_reference)
                 end
 
                 index += 1 if fupdate.after
@@ -468,13 +470,13 @@ class ViewModel::ActiveRecord
 
               # Assertion that all values in update_op.values are present in the collection
               unless new_datas.empty?
-                raise_deserialization_error(
-                  "Stale functional update for association '#{association_data.direct_reflection.name}' - "\
-                  "could not match referenced viewmodels: [#{new_datas.keys.map(&:to_s).join(', ')}]",
-                  error: ViewModel::DeserializationError::NotFound)
+                raise ViewModel::DeserializationError::AssociatedNotFound.new(
+                  association_data.association_name.to_s, new_datas.keys, blame_reference)
               end
             else
-              raise_deserialization_error("Unknown functional update type: '#{fupdate.type}'")
+              raise ViewModel::DeserializationError::InvalidSyntax.new(
+                "Unknown functional update type: '#{fupdate.type}'",
+                blame_reference)
             end
           end
 
@@ -549,13 +551,14 @@ class ViewModel::ActiveRecord
     # update operation. Elements removed from the collection are collected as
     # `orphaned_members`."
     class MutableReferencedCollection
-      attr_reader :members, :orphaned_members
+      attr_reader :members, :orphaned_members, :blame_reference
 
-      def initialize(association_data, update_context, members)
+      def initialize(association_data, update_context, members, blame_reference)
         @association_data = association_data
         @update_context   = update_context
-
         @members          = members.dup
+        @blame_reference  = blame_reference
+
         @orphaned_members = []
 
         @free_members_by_indirect_ref = @members.index_by(&:indirect_viewmodel_reference)
@@ -608,9 +611,8 @@ class ViewModel::ActiveRecord
         index = members.find_index { |m| m.indirect_viewmodel_reference == relative_vm_ref }
 
         unless index
-          raise ViewModel::DeserializationError::NotFound.new(
-            "Attempted to insert relative to reference that does not exist #{relative_vm_ref}",
-            [relative_vm_ref])
+          raise ViewModel::DeserializationError::AssociatedNotFound.new(
+            association_data.association_name.to_s, relative_vm_ref, blame_reference)
         end
 
         members.insert(index + offset, *new_members)
@@ -619,7 +621,7 @@ class ViewModel::ActiveRecord
       # Reclaim existing members corresponding to the specified references, or create new ones if not found.
       def claim_or_create_references(references)
         references.map do |ref_string|
-          indirect_vm_ref = update_context.resolve_reference(ref_string).viewmodel_reference
+          indirect_vm_ref = update_context.resolve_reference(ref_string, blame_reference).viewmodel_reference
           claim_or_create_member(indirect_vm_ref, ref_string)
         end
       end
@@ -636,7 +638,7 @@ class ViewModel::ActiveRecord
       # Reclaim existing members corresponding to the specified references or raise if not found.
       def claim_existing_references(references)
         references.each do |ref_string|
-          indirect_vm_ref = update_context.resolve_reference(ref_string).viewmodel_reference
+          indirect_vm_ref = update_context.resolve_reference(ref_string, blame_reference).viewmodel_reference
           claim_existing_member(indirect_vm_ref, ref_string)
         end
       end
@@ -644,9 +646,8 @@ class ViewModel::ActiveRecord
       # Claim an existing collection member for the update and optionally set its ref.
       def claim_existing_member(indirect_vm_ref, ref_string = nil)
         member = free_members_by_indirect_ref.delete(indirect_vm_ref) do
-          raise ViewModel::DeserializationError::NotFound.new(
-            "Stale functional update for association '#{association_data.direct_reflection.name}' - "\
-                  "could not match referenced viewmodel: '#{indirect_vm_ref}'")
+          raise ViewModel::DeserializationError::AssociatedNotFound.new(
+            association_data.association_name.to_s, indirect_vm_ref, blame_reference)
         end
         member.ref_string = ref_string if ref_string
         member
@@ -688,7 +689,7 @@ class ViewModel::ActiveRecord
       end
 
       target_collection = MutableReferencedCollection.new(
-        association_data, update_context, previous_members)
+        association_data, update_context, previous_members, blame_reference)
 
       # All updates to shared collections produce a complete target list of
       # ReferencedCollectionMembers including a ViewModel::Reference to the
@@ -738,7 +739,7 @@ class ViewModel::ActiveRecord
         end
 
       else
-        raise_deserialization_error("Unknown association_update type '#{association_update.class.name}'")
+        raise ViewModel::DeserializationError::InvalidSyntax.new("Unknown association_update type '#{association_update.class.name}'", blame_reference)
       end
 
       # We should now have an updated list of `target_collection_members`, each
@@ -791,8 +792,8 @@ class ViewModel::ActiveRecord
       end
     end
 
-    def raise_deserialization_error(msg, *args, error: ViewModel::DeserializationError)
-      raise error.new(msg, self.viewmodel.blame_reference, *args)
+    def blame_reference
+      self.viewmodel.blame_reference
     end
 
     def debug(msg)

--- a/lib/view_model/deserialization_error.rb
+++ b/lib/view_model/deserialization_error.rb
@@ -1,58 +1,331 @@
 class ViewModel
   class DeserializationError < ViewModel::AbstractError
     attr_reader :nodes
+    status 500
 
-    def initialize(detail, nodes = [])
-      super(detail)
+    def initialize(nodes)
       @nodes = Array.wrap(nodes)
-    end
-
-    def status
-      400
-    end
-
-    def metadata
-      blame_metadata(nodes)
+      super()
     end
 
     def code
-      "Deserialization.#{self.class.name.demodulize}"
+      "DeserializationError.#{self.class.name.demodulize}"
     end
 
-    class Permissions < DeserializationError
-      def status
-        403
+    def meta
+      blame_metadata(nodes)
+    end
+
+    protected
+
+    def viewmodel_class
+      first = nodes.first.viewmodel_class
+      unless nodes.all? { |n| n.viewmodel_class == first }
+        raise ArgumentError.new("All nodes must be of the same type for #{self.class.name}")
+      end
+      first
+    end
+
+    # A collection of DeserializationErrors
+    class Collection < ViewModel::AbstractErrorCollection
+      title "Error(s) occurred during deserialization"
+      code  "DeserializationError.Collection"
+
+      def detail
+        "Error(s) occurred during deserialization: #{cause_details}"
       end
     end
 
-    class SchemaMismatch < DeserializationError
+    # The client has provided a syntactically or structurally incoherent
+    # request.
+    class InvalidRequest < DeserializationError
+      # Abstract
+      status 400
+      title "Invalid request"
     end
 
+    # Abstract: an error with an arbitrary string detail taken as a constructor argument.
+    module WithDetail
+      extend ActiveSupport::Concern
+      included do
+        attr_reader :detail
+      end
+
+      def initialize(detail, nodes = nil)
+        @detail = detail
+        super(nodes)
+      end
+    end
+
+    # There has been an unexpected internal failure of the ViewModel library.
+    class Internal < DeserializationError
+      status 500
+      include WithDetail
+    end
+
+    class InvalidStructure < InvalidRequest
+      include WithDetail
+    end
+
+    class InvalidSyntax < InvalidRequest
+      include WithDetail
+    end
+
+    # A view included a invalid shared reference
+    class InvalidSharedReference < InvalidRequest
+      attr_reader :reference
+
+      def initialize(reference, node)
+        @reference = reference
+        super(node)
+      end
+
+      def detail
+        "Could not find shared reference with key '#{reference}'"
+      end
+
+      def meta
+        super.merge(reference: reference)
+      end
+    end
+
+    # A view was of an unknown type
+    class UnknownView < InvalidRequest
+      attr_reader :type
+
+      def initialize(type)
+        @type = type
+        super(nil)
+      end
+
+      def detail
+        "ViewModel class for view name '#{type}' could not be found"
+      end
+
+      def meta
+        super.merge(type: type)
+      end
+    end
+
+    # A view included an unknown attribute
+    class UnknownAttribute < InvalidRequest
+      attr_reader :attribute
+
+      def initialize(attribute, node)
+        @attribute = attribute
+        super(node)
+      end
+
+      def detail
+        "Unknown attribute/association #{attribute} in viewmodel '#{viewmodel_class.view_name}'"
+      end
+
+      def meta
+        super.merge(attribute: attribute)
+      end
+    end
+
+    # A view included an unexpected schema version for the corresponding
+    # viewmodel.
+    class SchemaVersionMismatch < InvalidRequest
+      attr_reader :viewmodel_class, :schema_version
+
+      def initialize(viewmodel_class, schema_version, nodes)
+        @viewmodel_class = viewmodel_class
+        @schema_version  = schema_version
+        super(nodes)
+      end
+
+      def detail
+        "Mismatched schema version for type #{viewmodel_class.view_name}, "\
+        "expected #{viewmodel_class.schema_version}, received #{schema_version}."
+      end
+
+      def meta
+        super.merge(expected: viewmodel_class.schema_version,
+                    received: schema_version)
+      end
+    end
+
+    # The target of an association was not a valid view type for that
+    # association.
+    class InvalidAssociationType < InvalidRequest
+      attr_reader :association, :target_type
+      def initialize(association, target_type, node)
+        @association = association
+        @target_type = target_type
+        super(node)
+      end
+
+      def detail
+        "Invalid target viewmodel type '#{target_type}' for association '#{association}'"
+      end
+
+      def meta
+        super.merge(association: association,
+                    target_type: target_type)
+      end
+    end
+
+    class InvalidViewType < InvalidRequest
+      attr_reader :expected_type
+
+      def initialize(expected_type, node)
+        @expected_type = expected_type
+        super(node)
+      end
+
+      def detail
+        "Cannot deserialize inappropriate view type, expected '#{expected_type}' or an alias"
+      end
+
+      def meta
+        super.merge(expected_type: expected_type)
+      end
+    end
+
+    # Attempted to load persisted viewmodels by id, but they were not available
     class NotFound < DeserializationError
-      def status
-        404
-      end
+      status 404
 
-      def self.wrap_lookup(*target_refs)
-        yield
-      rescue ::ActiveRecord::RecordNotFound => ex
-        raise self.new(ex.message, target_refs)
+      def detail
+        model_ids = nodes.map(&:model_id)
+        "Couldn't find #{viewmodel_class.view_name}(s) with id(s)=#{model_ids.inspect}"
       end
     end
 
+    class AssociatedNotFound < NotFound
+      attr_reader :missing_nodes, :association
+
+      def initialize(association, missing_nodes, nodes)
+        @association   = association
+        @missing_nodes = Array.wrap(missing_nodes)
+        super(nodes)
+      end
+
+      def detail
+        errors = missing_nodes.map(&:to_s).join(", ")
+        "Couldn't find requested member node(s) in association '#{association}': "\
+        "#{errors}"
+      end
+
+      def meta
+        super.merge(association: association,
+                    missing_nodes: format_references(missing_nodes))
+      end
+    end
+
+    class DuplicateNodes < InvalidRequest
+      attr_reader :type
+
+      def initialize(type, nodes)
+        @type = type
+        super(nodes)
+      end
+
+      def detail
+        "Duplicate views for the same '#{type}' specified: "+ nodes.map(&:to_s).join(", ")
+      end
+
+      def meta
+        super.merge(type: type)
+      end
+    end
+
+    class ParentNotFound < NotFound
+      def detail
+        "Could not resolve previous parents for the following referenced viewmodels: " +
+          nodes.map(&:to_s).join(", ")
+      end
+    end
+
+    class ReadOnlyAttribute < DeserializationError
+      status 400
+      attr_reader :attribute
+
+      def initialize(attribute, node)
+        @attribute = attribute
+        super(node)
+      end
+
+      def detail
+        "Cannot edit read only attribute '#{attribute}'"
+      end
+
+      def meta
+        super.merge(attribute: attribute)
+      end
+    end
+
+    class ReadOnlyType < DeserializationError
+      status 400
+      detail "Deserialization not defined for view type"
+    end
+
+    class InvalidAttributeType < InvalidRequest
+      attr_reader :attribute, :expected_type, :provided_type
+
+      def initialize(attribute, expected_type, provided_type, node)
+        @attribute     = attribute
+        @expected_type = expected_type
+        @provided_type = provided_type
+        super(node)
+      end
+
+      def detail
+        "Expected '#{attribute}' to be of type '#{expected_type}', was '#{provided_type}'"
+      end
+
+      def meta
+        super.merge(attribute:     attribute,
+                    expected_type: expected_type,
+                    provided_type: provided_type)
+      end
+    end
+
+    # Optimistic lock failure updating nodes
     class LockFailure < DeserializationError
+      status 400
+
+      def detail
+        errors = nodes.map(&:to_s).join(", ")
+        "Optimistic lock failure updating nodes: #{errors}"
+      end
+    end
+
+    class DatabaseConstraint < DeserializationError
+      status 400
+      include WithDetail
     end
 
     class Validation < DeserializationError
-      attr_reader :validation_errors
+      status 400
+      attr_reader :attribute, :reason, :details
 
-      def initialize(msg, nodes, validation_errors = nil)
-        super(msg, nodes)
-        @validation_errors = validation_errors
+      def initialize(attribute, reason, details, node)
+        @attribute = attribute
+        @reason    = reason
+        @details   = details
+        super(node)
       end
 
-      def metadata
-        super.merge(validation_errors: validation_errors)
+      def detail
+        "Validation failed: '#{attribute}' #{reason}"
+      end
+
+      def meta
+        super.merge(attribute: attribute, message: reason, details: details)
+      end
+
+      # Return Validation errors for each error in the the provided
+      # ActiveModel::Errors, wrapped in a Collection if necessary.
+      def self.from_active_model(errors, node)
+        causes = errors.messages.each_key.flat_map do |attr|
+          errors.messages[attr].zip(errors.details[attr]).map do |message, details|
+            self.new(attr.to_s, message, details, node)
+          end
+        end
+        Collection.for_errors(causes)
       end
     end
   end

--- a/lib/view_model/error.rb
+++ b/lib/view_model/error.rb
@@ -1,74 +1,157 @@
+# Abstract base for renderable errors in ViewModel-based APIs. Errors of this
+# type will be caught by ViewModel controllers and rendered in a standard format
+# by ViewModel::ErrorView, which loosely follows errors in JSON-API.
 class ViewModel::AbstractError < StandardError
-  def initialize(detail)
+  class << self
+    # Brief DSL for quickly defining constant attribute values in subclasses
+    [:detail, :status, :title, :code].each do |attribute|
+      define_method(attribute) do |x|
+        define_method(attribute){ x }
+      end
+    end
+  end
+
+  def initialize
+    # `detail` is used to provide the exception message. However, it's not safe
+    # to just override StandardError's `message` or `to_s` to call `detail`,
+    # since some of Ruby's C implementation of Exceptions internally ignores
+    # these methods and fetches the invisible internal `idMesg` attribute
+    # instead. (!)
+    #
+    # This means that all fields necessary to derive the detail message must be
+    # initialized before calling super().
     super(detail)
   end
 
-  def detail;   message; end
-  def status;   nil;     end
-  def title;    nil;     end
-  def code;     nil;     end
-  def metadata; {};      end
-
-  def view
-    ViewModel::Error::View.new(self)
+  # Human-readable reason for use displaying this error.
+  def detail
+    "ViewModel::AbstractError"
   end
 
+  # HTTP status code most appropriate for this error
+  def status
+    500
+  end
+
+  # Human-readable title for displaying this error
+  def title
+    nil
+  end
+
+  # Unique symbol identifying this error type
+  def code
+    "ViewModel.AbstractError"
+  end
+
+  # Additional information specific to this error type.
+  def meta
+    {}
+  end
+
+  # Some types of error may be aggregations over multiple causes
+  def aggregation?
+    false
+  end
+
+  # If so, the causes of this error (as AbstractErrors)
+  def causes
+    nil
+  end
+
+  # The exception responsible for this error. In most cases, that should be this
+  # object, but sometimes an Error may be used to wrap an external exception.
+  def exception
+    self
+  end
+
+  def view
+    ViewModel::ErrorView.new(self)
+  end
+
+  def to_s
+    detail
+  end
+
+  protected
+
+  # For errors associated with specific viewmodel nodes, create metadata
+  # describing the node to blame.
   def blame_metadata(viewmodel_refs)
     {
-      nodes: nodes.map do |ref|
-        {
-          ViewModel::TYPE_ATTRIBUTE => ref.viewmodel_class.view_name,
-          ViewModel::ID_ATTRIBUTE   => ref.model_id
-        }
-      end
+      nodes: format_references(viewmodel_refs)
+    }
+  end
+
+  def format_references(viewmodel_refs)
+    viewmodel_refs.map do |viewmodel_ref|
+      format_reference(viewmodel_ref)
+    end
+  end
+
+  def format_reference(viewmodel_ref)
+    {
+      ViewModel::TYPE_ATTRIBUTE => viewmodel_ref.viewmodel_class.view_name,
+      ViewModel::ID_ATTRIBUTE   => viewmodel_ref.model_id
     }
   end
 end
 
+# Abstract collection of errors
+class ViewModel::AbstractErrorCollection < ViewModel::AbstractError
+  attr_reader :causes
+
+  def initialize(causes)
+    @causes = Array.wrap(causes)
+    unless @causes.present?
+      raise ArgumentError.new("A collection must have at least one cause")
+    end
+    super()
+  end
+
+  def status
+    causes.inject(causes.first.status) do |status, cause|
+      if status == cause.status
+        status
+      else
+        400
+      end
+    end
+  end
+
+  def detail
+    "ViewModel::AbstractErrors: #{cause_details}"
+  end
+
+  def aggregation?
+    true
+  end
+
+  def self.for_errors(errors)
+    if errors.size == 1
+      errors.first
+    else
+      self.new(errors)
+    end
+  end
+
+  protected
+
+  def cause_details
+    causes.map(&:detail).join("; ")
+  end
+end
+
+# Implementation of ViewModel::AbstractError with constructor parameters for
+# each error data field.
 class ViewModel::Error < ViewModel::AbstractError
-  attr_reader :status, :title, :code, :metadata
+  attr_reader :detail, :status, :title, :code, :meta
 
-  def initialize(status: 400, detail: "ViewModel::Error", title: nil, code: nil, metadata: {})
-    super(detail)
-
-    @status   = status
-    @title    = title
-    @code     = code
-    @metadata = metadata
-  end
-
-  class View < ::ViewModel
-    attributes :error
-
-    def serialize_view(json, serialize_context: nil)
-      json.status error.status
-      json.detail error.detail if error.detail
-      json.title  error.title  if error.title
-      json.code   error.code   if error.code
-
-      json.meta do
-        ViewModel.serialize(error.metadata, json, serialize_context: serialize_context)
-      end
-
-      if Rails.env != 'production'
-        json.exception do
-          ExceptionDetailView.new(error).serialize(json, serialize_context: serialize_context)
-        end
-      end
-    end
-  end
-
-  class ExceptionDetailView < ::ViewModel
-    attributes :exception
-    def serialize_view(json, serialize_context: nil)
-      json.set! :class, exception.class.name
-      json.backtrace exception.backtrace
-      if cause = exception.cause
-        json.cause do
-          json.set! :class, cause.class.name
-          json.backtrace cause.backtrace
-        end
-      end
-    end
+  def initialize(status: 400, detail: "ViewModel Error", title: nil, code: nil, meta: {})
+    @detail = detail
+    @status = status
+    @title  = title
+    @code   = code
+    @meta   = meta
+    super()
   end
 end

--- a/lib/view_model/error.rb
+++ b/lib/view_model/error.rb
@@ -74,13 +74,7 @@ class ViewModel::AbstractError < StandardError
 
   protected
 
-  # For errors associated with specific viewmodel nodes, create metadata
-  # describing the node to blame.
-  def blame_metadata(viewmodel_refs)
-    {
-      nodes: format_references(viewmodel_refs)
-    }
-  end
+
 
   def format_references(viewmodel_refs)
     viewmodel_refs.map do |viewmodel_ref|
@@ -92,6 +86,23 @@ class ViewModel::AbstractError < StandardError
     {
       ViewModel::TYPE_ATTRIBUTE => viewmodel_ref.viewmodel_class.view_name,
       ViewModel::ID_ATTRIBUTE   => viewmodel_ref.model_id
+    }
+  end
+end
+
+# For errors associated with specific viewmodel nodes, include metadata
+# describing the node to blame.
+class ViewModel::AbstractErrorWithBlame < ViewModel::AbstractError
+  attr_reader :nodes
+
+  def initialize(blame_nodes)
+    @nodes = Array.wrap(blame_nodes)
+    super()
+  end
+
+  def meta
+    {
+      nodes: format_references(nodes)
     }
   end
 end

--- a/lib/view_model/error_view.rb
+++ b/lib/view_model/error_view.rb
@@ -1,0 +1,35 @@
+require 'view_model/record'
+
+# ViewModel for rendering ViewModel::AbstractErrors
+class ViewModel::ErrorView < ViewModel::Record
+  self.model_class = ViewModel::AbstractError
+  self.view_name = 'Error'
+
+  class ExceptionDetailView < ::ViewModel
+    attributes :exception
+    def serialize_view(json, serialize_context: nil)
+      json.set! :class, exception.class.name
+      json.backtrace exception.backtrace
+      if cause = exception.cause
+        json.cause do
+          json.set! :class, cause.class.name
+          json.backtrace cause.backtrace
+        end
+      end
+    end
+  end
+
+  attributes :status, :detail, :title, :code, :meta
+  attribute :causes, array: true, using: self
+  attribute :exception, using: ExceptionDetailView
+
+  # Ruby exceptions should never be serialized in production
+  def serialize_exception(json, serialize_context:)
+    super unless Rails.env == 'production'
+  end
+
+  # Only serialize causes for aggregation errors.
+  def serialize_causes(*)
+    super if model.aggregation?
+  end
+end

--- a/lib/view_model/record.rb
+++ b/lib/view_model/record.rb
@@ -266,7 +266,7 @@ class ViewModel::Record < ViewModel
 
     if attr_data.using_viewmodel? && !serialized_value.nil?
       vm_type = attr_data.attribute_viewmodel
-      ctx = deserialize_context.for_child(self)
+      ctx = deserialize_context.for_child(self, association_name: attr.to_s)
       if attr_data.array?
         expect_type!(attr, Array, serialized_value)
         value = serialized_value.map { |v| vm_type.deserialize_from_view(v, references: references, deserialize_context: ctx) }

--- a/lib/view_model/record.rb
+++ b/lib/view_model/record.rb
@@ -1,5 +1,3 @@
-require 'view_model/schemas'
-
 # Abstract ViewModel type for serializing a subset of attributes from a record.
 # A record viewmodel wraps a single underlying model, exposing a fixed set of
 # real or calculated attributes.
@@ -62,16 +60,14 @@ class ViewModel::Record < ViewModel
         metadata = ViewModel.extract_viewmodel_metadata(view_hash)
 
         unless self.view_name == metadata.view_name || self.view_aliases.include?(metadata.view_name)
-          raise ViewModel::DeserializationError.new(
-                  "Cannot deserialize type #{metadata.view_name}, expected #{[self.view_name, *self.view_aliases]}.",
+          raise ViewModel::DeserializationError::InvalidViewType.new(
+                  self.view_name,
                   ViewModel::Reference.new(self, metadata.id))
         end
 
         if metadata.schema_version && !self.accepts_schema_version?(metadata.schema_version)
-          raise ViewModel::DeserializationError::SchemaMismatch.new(
-                  "Mismatched schema version for type #{self.view_name}, "\
-                  "expected #{self.schema_version}, received #{metadata.schema_version}.",
-                  ViewModel::Reference.new(self, metadata.id))
+          raise ViewModel::DeserializationError::SchemaVersionMismatch.new(
+                  self, version, ViewModel::Reference.new(self, metadata.id))
         end
 
         viewmodel = resolve_viewmodel(metadata, view_hash, deserialize_context: deserialize_context)
@@ -88,8 +84,10 @@ class ViewModel::Record < ViewModel
       deserialize_context.visible!(viewmodel)
 
       if (bad_attrs = view_hash.keys - self.member_names).present?
-        raise ViewModel::DeserializationError.new("Illegal attribute(s) #{bad_attrs.inspect} for viewmodel #{self.view_name}",
-                                                  viewmodel.blame_reference)
+        causes = bad_attrs.map do |bad_attr|
+          ViewModel::DeserializationError::UnknownAttribute.new(bad_attr, viewmodel.blame_reference)
+        end
+        raise ViewModel::DeserializationError::Collection.for_errors(causes)
       end
 
       initial_editability = deserialize_context.initial_editability(viewmodel)
@@ -192,10 +190,7 @@ class ViewModel::Record < ViewModel
   # DeserializationError::Validation if invalid.
   def validate!
     if model_class < ActiveModel::Validations && !model.valid?
-      raise ViewModel::DeserializationError::Validation.new(
-              "Validation failed: " + model.errors.full_messages.join(", "),
-              self.blame_reference,
-              model.errors.messages)
+      raise ViewModel::DeserializationError::Validation.from_active_model(model.errors, self.blame_reference)
     end
   end
 
@@ -285,7 +280,7 @@ class ViewModel::Record < ViewModel
     # Detect changes with ==. In the case of `using_viewmodel?`, this compares viewmodels or arrays of viewmodels.
     if value != self.public_send(attr)
       if attr_data.read_only? && !(attr_data.write_once? && new_model?)
-        raise ViewModel::DeserializationError.new("Cannot edit read only attribute: #{attr}", self.blame_reference)
+        raise ViewModel::DeserializationError::ReadOnlyAttribute.new(attr.to_s, blame_reference)
       end
 
       attribute_changed!(attr)
@@ -307,7 +302,10 @@ class ViewModel::Record < ViewModel
   # DeserializationError unless the serialized value is of the provided type.
   def expect_type!(attribute, type, serialized_value)
     unless serialized_value.is_a?(type)
-      raise DeserializationError.new("Expected '#{attribute}' to be '#{type.name}', was '#{serialized_value.class}'", blame_reference)
+      raise ViewModel::DeserializationError::InvalidAttributeType.new(attribute.to_s,
+                                                                      type.name,
+                                                                      serialized_value.class.name,
+                                                                      blame_reference)
     end
   end
 end

--- a/lib/view_model/reference.rb
+++ b/lib/view_model/reference.rb
@@ -9,7 +9,7 @@ class ViewModel
     end
 
     def to_s
-      "'#{viewmodel_class.view_name}(#{model_id})'"
+      "'#{viewmodel_class.view_name}(id=#{model_id})'"
     end
 
     def ==(other)

--- a/lib/view_model/registry.rb
+++ b/lib/view_model/registry.rb
@@ -13,7 +13,7 @@ class ViewModel::Registry
   end
 
   def for_view_name(name)
-    raise ViewModel::DeserializationError.new("ViewModel name cannot be nil") if name.nil?
+    raise ViewModel::DeserializationError::InvalidSyntax.new("ViewModel name cannot be nil") if name.nil?
 
     # Resolve names for any deferred viewmodel classes
     until @deferred_viewmodel_classes.empty? do
@@ -28,7 +28,7 @@ class ViewModel::Registry
     viewmodel_class = @viewmodel_classes_by_name[name]
 
     if viewmodel_class.nil? || !(viewmodel_class < ViewModel)
-      raise ViewModel::DeserializationError.new("ViewModel class for view name '#{name}' not found")
+      raise ViewModel::DeserializationError::UnknownView.new(name)
     end
 
     viewmodel_class

--- a/lib/view_model/schemas.rb
+++ b/lib/view_model/schemas.rb
@@ -1,4 +1,3 @@
-require 'view_model'
 require 'json'
 require 'json_schema'
 
@@ -40,7 +39,7 @@ class ViewModel::Schemas
     unless valid
       error_list = errors.map { |e| "#{e.pointer}: #{e.message}" }.join("\n")
       errors     = 'Error'.pluralize(errors.length)
-      raise ViewModel::DeserializationError.new("#{errors} parsing #{schema.description}:\n#{error_list}")
+      raise ViewModel::DeserializationError::InvalidSyntax.new("#{errors} parsing #{schema.description}:\n#{error_list}")
     end
   end
 end

--- a/lib/view_model/serialization_error.rb
+++ b/lib/view_model/serialization_error.rb
@@ -1,17 +1,10 @@
-class ViewModel
-  class SerializationError < ViewModel::AbstractError
-    def status
-      400
-    end
+class ViewModel::SerializationError < ViewModel::AbstractError
+  attr_reader :detail
+  status 400
+  code "SerializationError"
 
-    def code
-      "Serialization.#{self.class.name.demodulize}"
-    end
-
-    class Permissions < SerializationError
-      def status
-        403
-      end
-    end
+  def initialize(detail)
+    @detail = detail
+    super()
   end
 end

--- a/lib/view_model/serialize_context.rb
+++ b/lib/view_model/serialize_context.rb
@@ -34,6 +34,7 @@ class ViewModel::SerializeContext < ViewModel::TraversalContext
 
   def for_child(parent_viewmodel, association_name:, **rest)
     super(parent_viewmodel,
+          association_name: association_name,
           include: @include.try { |i| i[association_name] },
           prune:   @prune.try   { |p| p[association_name] },
           **rest)

--- a/lib/view_model/traversal_context.rb
+++ b/lib/view_model/traversal_context.rb
@@ -29,22 +29,25 @@ class ViewModel::TraversalContext
     @shared_context   = shared_context || self.class.shared_context_class.new(**shared_context_params)
     @parent_context   = nil
     @parent_viewmodel = nil
+    @parent_association = nil
   end
 
   # Overloaded constructor for initialization of descendent node contexts.
   # Shared context is the same, ancestry is established, and subclasses can
   # override to maintain other node-specific state.
-  def initialize_as_child(shared_context:, parent_context:, parent_viewmodel:)
+  def initialize_as_child(shared_context:, parent_context:, parent_viewmodel:, parent_association:)
     super()
     @shared_context = shared_context
     @parent_context = parent_context
     @parent_viewmodel = parent_viewmodel
+    @parent_association = parent_association
   end
 
-  def for_child(parent_viewmodel, **rest)
+  def for_child(parent_viewmodel, association_name:, **rest)
     self.class.new_child(shared_context: shared_context,
                          parent_context: self,
                          parent_viewmodel: parent_viewmodel,
+                         parent_association: association_name,
                          **rest)
   end
 
@@ -61,6 +64,14 @@ class ViewModel::TraversalContext
       @parent_viewmodel
     else
       parent_context(idx - 1)&.parent_viewmodel
+    end
+  end
+
+  def parent_association(idx = 0)
+    if idx == 0
+      @parent_association
+    else
+      parent_context(idx - 1)&.parent_association
     end
   end
 

--- a/test/unit/view_model/active_record/controller_test.rb
+++ b/test/unit/view_model/active_record/controller_test.rb
@@ -119,10 +119,14 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     parentcontroller.invoke(:show)
 
     assert_equal(404, parentcontroller.status)
-    assert_equal({ 'errors' => [{ 'status' => 404,
-                                  'detail' => "Couldn't find Parent(s) with id(s)=[9999]",
-                                  'code'   => "Deserialization.NotFound",
-                                  'meta' => { 'nodes' => [{ '_type' => "Parent", 'id' => 9999 }]}}]},
+    assert_equal({ 'error' => {
+                     ViewModel::TYPE_ATTRIBUTE => ViewModel::ErrorView.view_name,
+                     ViewModel::VERSION_ATTRIBUTE => ViewModel::ErrorView.schema_version,
+                     'status' => 404,
+                     'detail' => "Couldn't find Parent(s) with id(s)=[9999]",
+                     'title' => nil,
+                     'code'   => "DeserializationError.NotFound",
+                     'meta' => { 'nodes' => [{ '_type' => "Parent", 'id' => 9999 }]}}},
                  parentcontroller.hash_response)
   end
 
@@ -134,11 +138,17 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     parentcontroller = ParentController.new(data: data)
     parentcontroller.invoke(:create)
 
-    assert_equal({ 'errors' => [{ 'status' => 400,
-                                  'detail' => 'Validation failed: Age must be less than 42',
-                                  'code'   => "Deserialization.Validation",
-                                  'meta' => { 'nodes' => [{ '_type' => "Child", 'id' => nil }],
-                                              'validation_errors' => { 'age' => ["must be less than 42"]}}}] },
+    assert_equal({ 'error' => {
+                     ViewModel::TYPE_ATTRIBUTE => ViewModel::ErrorView.view_name,
+                     ViewModel::VERSION_ATTRIBUTE => ViewModel::ErrorView.schema_version,
+                     'status' => 400,
+                     'detail' => 'Validation failed: \'age\' must be less than 42',
+                     'title' => nil,
+                     'code'   => "DeserializationError.Validation",
+                     'meta' => { 'nodes' => [{ '_type' => "Child", 'id' => nil }],
+                                 'attribute' => 'age',
+                                 'message' => 'must be less than 42',
+                                 'details' => { 'error' => 'less_than', 'value' => 42, 'count' => 42 }}}},
                  parentcontroller.hash_response)
   end
 
@@ -151,7 +161,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
 
     assert_equal(400, parentcontroller.status)
     assert_match(%r{check constraint}i,
-                 parentcontroller.hash_response["errors"].first["detail"],
+                 parentcontroller.hash_response["error"]["detail"],
                  "Database error propagated")
   end
 
@@ -159,10 +169,14 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     parentcontroller = ParentController.new(id: 9999)
     parentcontroller.invoke(:destroy)
 
-    assert_equal({ 'errors' => [{ 'status' => 404,
-                                  'detail' => "Couldn't find Parent(s) with id(s)=[9999]",
-                                  'code'   => "Deserialization.NotFound",
-                                  'meta' => { "nodes" => [{"_type" => "Parent", "id" => 9999}]}}] },
+    assert_equal({ 'error' => {
+                     ViewModel::TYPE_ATTRIBUTE => ViewModel::ErrorView.view_name,
+                     ViewModel::VERSION_ATTRIBUTE => ViewModel::ErrorView.schema_version,
+                     'status' => 404,
+                     'detail' => "Couldn't find Parent(s) with id(s)=[9999]",
+                     'title' => nil,
+                     'code'   => "DeserializationError.NotFound",
+                     'meta' => { "nodes" => [{"_type" => "Parent", "id" => 9999}]}} },
                  parentcontroller.hash_response)
     assert_equal(404, parentcontroller.status)
   end

--- a/test/unit/view_model/active_record/version_test.rb
+++ b/test/unit/view_model/active_record/version_test.rb
@@ -81,7 +81,7 @@ class ViewModel::ActiveRecord::VersionTest < ActiveSupport::TestCase
   end
 
   def test_regular_version_verification
-    ex = assert_raise(ViewModel::DeserializationError::SchemaMismatch) do
+    ex = assert_raise(ViewModel::DeserializationError::SchemaVersionMismatch) do
       ParentView.deserialize_from_view(
         { '_type'    => 'Parent',
           '_new'     => true,
@@ -91,7 +91,7 @@ class ViewModel::ActiveRecord::VersionTest < ActiveSupport::TestCase
   end
 
   def test_polymorphic_version_verification
-    ex = assert_raise(ViewModel::DeserializationError::SchemaMismatch) do
+    ex = assert_raise(ViewModel::DeserializationError::SchemaVersionMismatch) do
       ParentView.deserialize_from_view(
         { '_type' => 'Parent',
           '_new'  => true,
@@ -104,7 +104,7 @@ class ViewModel::ActiveRecord::VersionTest < ActiveSupport::TestCase
   end
 
   def test_shared_parse_version_verification
-    ex = assert_raise(ViewModel::DeserializationError::SchemaMismatch) do
+    ex = assert_raise(ViewModel::DeserializationError::SchemaVersionMismatch) do
       ParentView.deserialize_from_view(
         { '_type'  => 'Parent',
           '_new'   => true,


### PR DESCRIPTION
Expect only one error from viewmodel api requests.

Add container type errors to allow like errors (e.g. deserialization errors) to be bundled.

Add many more individual named deserialization error types rather than throwing with ad-hoc messages.

Will require equivalent front-end refactor.