### PR TITLE
top level serialize: serializing an empty hash should do something

### DIFF
--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -122,6 +122,7 @@ class ViewModel
           serialize(elt, json, serialize_context: serialize_context)
         end
       when Hash, Struct
+        json.merge!({})
         target.each_pair do |key, value|
           json.set! key do
             serialize(value, json, serialize_context: serialize_context)

--- a/test/unit/view_model_test.rb
+++ b/test/unit/view_model_test.rb
@@ -9,7 +9,7 @@ end
 
 class TestViewModel < ViewModel
   attributes :val
-  def serialize_view(json, **options)
+  def serialize_view(json, **_options)
     json.name val
   end
 end
@@ -37,6 +37,12 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
     s = DefaultViewModel.new("a", { "x" => "y" })
     assert_equal(DefaultViewModel.serialize_to_hash(s),
                  { "foo" => "a", "bar" => { "x" => "y" } })
+  end
+
+  def test_default_serialize_empty_hash
+    s = DefaultViewModel.new("a", {})
+    assert_equal(DefaultViewModel.serialize_to_hash(s),
+                 { "foo" => "a", "bar" => {} })
   end
 
   def test_default_serialize_viewmodel


### PR DESCRIPTION
Jbuilder set! omits keys if the builder was not modified during the value
block evaluation. We want our `serialize`'d keys to exist even if the value
is an empty hash: force the result to exist as an empty object with
`merge!({})` before iterating.