### PR TITLE
Don't force realization of non Record viewmodels

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,3 +1,3 @@
 module IknowViewModels
-  VERSION = "2.3.0"
+  VERSION = "2.3.1"
 end

--- a/lib/view_model/test_helpers/arvm_builder.rb
+++ b/lib/view_model/test_helpers/arvm_builder.rb
@@ -52,7 +52,9 @@ class ViewModel::TestHelpers::ARVMBuilder
     # Force the realization of the view model into the library's lookup
     # table. If this doesn't happen the library may have conflicting entries in
     # the deferred table, and will allow viewmodels to leak between tests.
-    ViewModel::Registry.for_view_name(viewmodel.view_name) unless @no_viewmodel
+    unless @no_viewmodel || !(@viewmodel < ViewModel::Record)
+      ViewModel::Registry.for_view_name(viewmodel.view_name)
+    end
   end
 
   def teardown


### PR DESCRIPTION
Permits test setups that have viewmodels that rely on database tables
and models, without actually being a ViewModel::Record subtype for
that model.