### PR TITLE
Use child contexts when dealing with associations in nested controllers

### DIFF
--- a/lib/view_model/active_record/association_manipulation.rb
+++ b/lib/view_model/active_record/association_manipulation.rb
@@ -33,7 +33,10 @@ module AssociationManipulation
 
     vms = association_scope.map { |model| associated_viewmodel.new(model) }
 
-    ViewModel.preload_for_serialization(vms, serialize_context: serialize_context) if eager_include
+    if eager_include
+      child_context = serialize_context.for_child(self, association_name: association_name)
+      ViewModel.preload_for_serialization(vms, serialize_context: child_context)
+    end
 
     if association_data.collection?
       vms

--- a/lib/view_model/active_record/collection_nested_controller.rb
+++ b/lib/view_model/active_record/collection_nested_controller.rb
@@ -60,8 +60,9 @@ module ViewModel::ActiveRecord::CollectionNestedController
                                                 after:      after,
                                                 deserialize_context: deserialize_context)
 
-      ViewModel.preload_for_serialization(assoc_view, serialize_context: serialize_context)
-      prerender_viewmodel(assoc_view, serialize_context: serialize_context)
+      child_context = serialize_context.for_child(owner_viewmodel, association_name: association_name)
+      ViewModel.preload_for_serialization(assoc_view, serialize_context: child_context)
+      prerender_viewmodel(assoc_view, serialize_context: child_context)
     end
     finish_render_viewmodel(pre_rendered)
     assoc_view


### PR DESCRIPTION
Logically we're dealing with children of a top level entity, so construct child contexts before serialization.