### PR TITLE
AssociationManipulation needs to consider whether children are shared when constructing traversal contexts

### DIFF
--- a/lib/view_model/active_record/association_data.rb
+++ b/lib/view_model/active_record/association_data.rb
@@ -26,6 +26,14 @@ class ViewModel::ActiveRecord::AssociationData
     end
 
     if through?
+      # Through associations must always be an owned direct association to a
+      # shared indirect target. We expect the user to set shared: true to
+      # express the ownership of the indirect target, but this direct
+      # association to the intermediate is in fact owned. This ownership
+      # property isn't directly used anywhere: the synthetic intermediate
+      # viewmodel is only used in the deserialization update operations, which
+      # directly understands the semantics of through associations.
+      raise ArgumentError.new("Through associations must be to a shared target") unless @shared
       raise ArgumentError.new("Through associations must be `has_many`") unless direct_reflection.macro == :has_many
     end
   end

--- a/lib/view_model/active_record/association_manipulation.rb
+++ b/lib/view_model/active_record/association_manipulation.rb
@@ -34,7 +34,7 @@ module ViewModel::ActiveRecord::AssociationManipulation
     vms = association_scope.map { |model| associated_viewmodel.new(model) }
 
     if eager_include
-      child_context = serialize_context.for_child(self, association_name: association_name)
+      child_context = serialize_context.for_child(self, association_name: association_name, root: association_data.shared?)
       ViewModel.preload_for_serialization(vms, serialize_context: child_context)
     end
 
@@ -131,7 +131,7 @@ module ViewModel::ActiveRecord::AssociationManipulation
             end
           end
 
-          updated_viewmodels = update_context.run!(deserialize_context: deserialize_context.for_child(self, association_name: association_name))
+          updated_viewmodels = update_context.run!(deserialize_context: deserialize_context.for_child(self, association_name: association_name, root: association_data.shared?))
 
           if association_data.through?
             updated_viewmodels.map! do |direct_vm|

--- a/lib/view_model/active_record/collection_nested_controller.rb
+++ b/lib/view_model/active_record/collection_nested_controller.rb
@@ -50,7 +50,6 @@ module ViewModel::ActiveRecord::CollectionNestedController
         raise ViewModel::DeserializationError::InvalidSyntax.new("Can not provide both `before` and `after` anchors for a collection append")
       end
 
-
       owner_view = owner_viewmodel.find(owner_viewmodel_id, eager_include: false, serialize_context: serialize_context)
 
       assoc_view = owner_view.append_associated(association_name,
@@ -60,7 +59,9 @@ module ViewModel::ActiveRecord::CollectionNestedController
                                                 after:      after,
                                                 deserialize_context: deserialize_context)
 
-      child_context = serialize_context.for_child(owner_viewmodel, association_name: association_name)
+      association_data = owner_viewmodel._association_data(association_name)
+      child_context = serialize_context.for_child(owner_viewmodel, association_name: association_name, root: association_data.shared?)
+
       ViewModel.preload_for_serialization(assoc_view, serialize_context: child_context)
       prerender_viewmodel(assoc_view, serialize_context: child_context)
     end

--- a/lib/view_model/active_record/nested_controller_base.rb
+++ b/lib/view_model/active_record/nested_controller_base.rb
@@ -14,7 +14,7 @@ module ViewModel::ActiveRecord::NestedControllerBase
 
         associated_views = yield(associated_views) if block_given?
 
-        child_context = serialize_context.for_child(owner_viewmodel, association_name: association_name)
+        child_context = serialize_context.for_child(owner_viewmodel, association_name: association_name, root: association_data.shared?)
         prerender_viewmodel(associated_views, serialize_context: child_context)
       end
     end
@@ -33,7 +33,7 @@ module ViewModel::ActiveRecord::NestedControllerBase
                                                        references: refs,
                                                        deserialize_context: deserialize_context)
 
-      child_context = serialize_context.for_child(owner_viewmodel, association_name: association_name)
+      child_context = serialize_context.for_child(owner_viewmodel, association_name: association_name, root: association_data.shared?)
       ViewModel.preload_for_serialization(association_view, serialize_context: child_context)
       prerender_viewmodel(association_view, serialize_context: child_context)
     end


### PR DESCRIPTION
So that they can be visited with `root` set appropriately, among other things