### PR TITLE
Traversal context cleanup and tests

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,3 +1,3 @@
 module IknowViewModels
-  VERSION = "2.4.0"
+  VERSION = "2.4.1"
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -250,6 +250,10 @@ class ViewModel
     to_reference
   end
 
+  def context_for_child(member_name, context:)
+    context.for_child(self, association_name: member_name)
+  end
+
   def preload_for_serialization(lock: nil, serialize_context: self.class.new_serialize_context)
     ViewModel.preload_for_serialization([self], lock: lock, serialize_context: serialize_context)
   end

--- a/lib/view_model/access_control.rb
+++ b/lib/view_model/access_control.rb
@@ -90,8 +90,6 @@ class ViewModel::AccessControl
   include ViewModel::Callbacks
 
   before_visit do
-    next if ineligible(view)
-
     result = visible_check(self)
 
     raise_if_error!(result) do
@@ -102,16 +100,12 @@ class ViewModel::AccessControl
   end
 
   before_deserialize do
-    next if ineligible(view)
-
     initial_result = editable_check(self)
 
     save_editability(view, initial_result)
   end
 
   on_change do
-    next if ineligible(view)
-
     initial_result = fetch_editability(view)
     result = initial_result.merge do
       valid_edit_check(self)
@@ -125,7 +119,6 @@ class ViewModel::AccessControl
   end
 
   after_deserialize do
-    next if ineligible(view)
     # If there was no change to consume the initial editability we still want to clean it up
     cleanup_editability(view)
   end
@@ -148,13 +141,6 @@ class ViewModel::AccessControl
 
   def cleanup_editability(view)
     @initial_editability_store.delete(view.object_id)
-  end
-
-  def ineligible(view)
-    # ARVM synthetic views are considered part of their association and as such
-    # are not edit checked. Eligibility exclusion is intended to be
-    # library-internal: subclasses should not attempt to extend this.
-    view.is_a?(ViewModel::ActiveRecord) && view.class.synthetic
   end
 
   def raise_if_error!(result)

--- a/lib/view_model/active_record/association_manipulation.rb
+++ b/lib/view_model/active_record/association_manipulation.rb
@@ -34,7 +34,7 @@ module ViewModel::ActiveRecord::AssociationManipulation
     vms = association_scope.map { |model| associated_viewmodel.new(model) }
 
     if eager_include
-      child_context = serialize_context.for_child(self, association_name: association_name, root: association_data.shared?)
+      child_context = self.context_for_child(association_name, context: serialize_context)
       ViewModel.preload_for_serialization(vms, serialize_context: child_context)
     end
 
@@ -133,7 +133,8 @@ module ViewModel::ActiveRecord::AssociationManipulation
             end
           end
 
-          updated_viewmodels = update_context.run!(deserialize_context: deserialize_context.for_child(self, association_name: association_name, root: association_data.shared?))
+          child_context = self.context_for_child(association_name, context: deserialize_context)
+          updated_viewmodels = update_context.run!(deserialize_context: child_context)
 
           if association_data.through?
             updated_viewmodels.map! do |direct_vm|
@@ -200,7 +201,7 @@ module ViewModel::ActiveRecord::AssociationManipulation
                   blame_reference)
         end
 
-        child_context = deserialize_context.for_child(self, association_name: association_name)
+        child_context = self.context_for_child(association_name, context: deserialize_context)
         child_vm = direct_viewmodel.new(models.first)
 
         ViewModel::Callbacks.wrap_deserialize(child_vm, deserialize_context: child_context) do |child_hook_control|

--- a/lib/view_model/active_record/collection_nested_controller.rb
+++ b/lib/view_model/active_record/collection_nested_controller.rb
@@ -59,9 +59,7 @@ module ViewModel::ActiveRecord::CollectionNestedController
                                                 after:      after,
                                                 deserialize_context: deserialize_context)
 
-      association_data = owner_viewmodel._association_data(association_name)
-      child_context = serialize_context.for_child(owner_viewmodel, association_name: association_name, root: association_data.shared?)
-
+      child_context = owner_view.context_for_child(association_name, context: serialize_context)
       ViewModel.preload_for_serialization(assoc_view, serialize_context: child_context)
       prerender_viewmodel(assoc_view, serialize_context: child_context)
     end

--- a/lib/view_model/active_record/nested_controller_base.rb
+++ b/lib/view_model/active_record/nested_controller_base.rb
@@ -14,7 +14,7 @@ module ViewModel::ActiveRecord::NestedControllerBase
 
         associated_views = yield(associated_views) if block_given?
 
-        child_context = serialize_context.for_child(owner_viewmodel, association_name: association_name, root: association_data.shared?)
+        child_context = owner_view.context_for_child(association_name, context: serialize_context)
         prerender_viewmodel(associated_views, serialize_context: child_context)
       end
     end
@@ -33,7 +33,7 @@ module ViewModel::ActiveRecord::NestedControllerBase
                                                        references: refs,
                                                        deserialize_context: deserialize_context)
 
-      child_context = serialize_context.for_child(owner_viewmodel, association_name: association_name, root: association_data.shared?)
+      child_context = owner_view.context_for_child(association_name, context: serialize_context)
       ViewModel.preload_for_serialization(association_view, serialize_context: child_context)
       prerender_viewmodel(association_view, serialize_context: child_context)
     end

--- a/lib/view_model/active_record/update_data.rb
+++ b/lib/view_model/active_record/update_data.rb
@@ -595,15 +595,15 @@ class ViewModel::ActiveRecord
       deps
     end
 
-    def build_preload_specs(association_data, updates, referenced_updates)
+    def build_preload_specs(association_data, updates)
       if association_data.polymorphic?
         updates.map do |update_data|
           target_model = update_data.viewmodel_class.model_class
           DeepPreloader::PolymorphicSpec.new(
-            target_model.name => update_data.preload_dependencies(referenced_updates))
+            target_model.name => update_data.preload_dependencies)
         end
       else
-        updates.map { |update_data| update_data.preload_dependencies(referenced_updates) }
+        updates.map { |update_data| update_data.preload_dependencies }
       end
     end
 
@@ -614,15 +614,14 @@ class ViewModel::ActiveRecord
 
     # Updates in terms of activerecord associations: used for preloading subtree
     # associations necessary to perform update.
-    def preload_dependencies(referenced_updates)
+    def preload_dependencies
       deps = {}
 
       (associations.merge(referenced_associations)).each do |assoc_name, reference|
         association_data = self.viewmodel_class._association_data(assoc_name)
 
         preload_specs = build_preload_specs(association_data,
-                                            to_sequence(assoc_name, reference),
-                                            referenced_updates)
+                                            to_sequence(assoc_name, reference))
 
         referenced_deps = merge_preload_specs(association_data, preload_specs)
 

--- a/lib/view_model/active_record/visitor.rb
+++ b/lib/view_model/active_record/visitor.rb
@@ -33,7 +33,7 @@ class ViewModel::ActiveRecord::Visitor
         children = Array.wrap(view._read_association(name))
         children.each do |child|
           if context
-            child_context = context.for_child(view, association_name: name, root: member_data.shared?)
+            child_context = view.context_for_child(name, context: context)
           end
           self.visit(child, context: child_context)
         end

--- a/lib/view_model/record.rb
+++ b/lib/view_model/record.rb
@@ -305,7 +305,7 @@ class ViewModel::Record < ViewModel
     end
 
     json.set! vm_attr_name do
-      serialize_context = serialize_context.for_child(self, association_name: vm_attr_name) if attr_data.using_viewmodel?
+      serialize_context = self.context_for_child(vm_attr_name, context: serialize_context) if attr_data.using_viewmodel?
       self.class.serialize(value, json, serialize_context: serialize_context)
     end
   end
@@ -322,7 +322,7 @@ class ViewModel::Record < ViewModel
       when serialized_value.nil?
         serialized_value
       when attr_data.using_viewmodel?
-        ctx = deserialize_context.for_child(self, association_name: vm_attr_name)
+        ctx = self.context_for_child(vm_attr_name, context: deserialize_context)
         attr_data.map_value(serialized_value) do |sv|
           attr_data.attribute_viewmodel.deserialize_from_view(sv, references: references, deserialize_context: ctx)
         end

--- a/lib/view_model/reference.rb
+++ b/lib/view_model/reference.rb
@@ -12,6 +12,10 @@ class ViewModel
       "'#{viewmodel_class.view_name}(id=#{model_id})'"
     end
 
+    def inspect
+      "<Ref:#{self}>"
+    end
+
     def ==(other)
       other.class             == self.class &&
         other.viewmodel_class == viewmodel_class &&

--- a/lib/view_model/serialize_context.rb
+++ b/lib/view_model/serialize_context.rb
@@ -40,12 +40,6 @@ class ViewModel::SerializeContext < ViewModel::TraversalContext
           **rest)
   end
 
-  # Obtain a semi-independent context for serializing references: keep the same
-  # shared context, but drop any tree location specific local context.
-  def for_references
-    self.class.new(shared_context: shared_context)
-  end
-
   def includes_member?(member_name, default)
     member_name = member_name.to_s
 

--- a/lib/view_model/traversal_context.rb
+++ b/lib/view_model/traversal_context.rb
@@ -39,22 +39,29 @@ class ViewModel::TraversalContext
   # Overloaded constructor for initialization of descendent node contexts.
   # Shared context is the same, ancestry is established, and subclasses can
   # override to maintain other node-specific state.
-  def initialize_as_child(shared_context:, parent_context:, parent_viewmodel:, parent_association:, root:)
+  def initialize_as_child(shared_context:, parent_context:, parent_viewmodel:, parent_association:)
     @shared_context     = shared_context
     @parent_context     = parent_context
     @parent_viewmodel   = parent_viewmodel
     @parent_association = parent_association
-    @root               = root
+    @root               = false
   end
 
-  def for_child(parent_viewmodel, association_name:, root: false, **rest)
+  def for_child(parent_viewmodel, association_name:, **rest)
     self.class.new_child(
       shared_context:     shared_context,
       parent_context:     self,
       parent_viewmodel:   parent_viewmodel,
       parent_association: association_name,
-      root:               root,
       **rest)
+  end
+
+  # Obtain a semi-independent context for descending through a shared reference:
+  # keep the same shared context, but drop any tree location specific local
+  # context (since a shared reference could equally have been reached via any
+  # parent)
+  def for_references
+    self.class.new(shared_context: shared_context)
   end
 
   def parent_context(idx = 0)

--- a/test/helpers/match_enumerator.rb
+++ b/test/helpers/match_enumerator.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# From https://stackoverflow.com/a/41293357
+module MiniTest::Assertions
+  class MatchEnumerator
+    def initialize(expected, actual)
+      @expected = expected
+      @actual = actual
+    end
+
+    def match
+      return result, message
+    end
+
+    def result
+      return false unless @actual.respond_to? :to_a
+      @extra_items = difference_between_enumerators(@actual, @expected)
+      @missing_items = difference_between_enumerators(@expected, @actual)
+      @extra_items.empty? & @missing_items.empty?
+    end
+
+    def message
+      if @actual.respond_to? :to_a
+        message = "expected collection contained: #{safe_sort(@expected).inspect}\n"
+        message += "actual collection contained: #{safe_sort(@actual).inspect}\n"
+        message += "the missing elements were: #{safe_sort(@missing_items).inspect}\n" unless @missing_items.empty?
+        message += "the extra elements were: #{safe_sort(@extra_items).inspect}\n" unless @extra_items.empty?
+      else
+        message = "expected an array, actual collection was #{@actual.inspect}"
+      end
+
+      message
+    end
+
+    private
+
+    def safe_sort(array)
+      array.sort rescue array
+    end
+
+    def difference_between_enumerators(array_1, array_2)
+      difference = array_1.to_a.dup
+      array_2.to_a.each do |element|
+        if (index = difference.index(element))
+          difference.delete_at(index)
+        end
+      end
+      difference
+    end
+  end # MatchEnumerator
+
+  def assert_match_enumerator(expected, actual)
+    result, message = MatchEnumerator.new(expected, actual).match
+    assert result, message
+  end
+end # MiniTest::Assertions
+
+Enumerator.infect_an_assertion :assert_match_enumerator, :must_contain_exactly

--- a/test/helpers/viewmodel_spec_helpers.rb
+++ b/test/helpers/viewmodel_spec_helpers.rb
@@ -23,6 +23,14 @@ module ViewModelSpecHelpers
       Object
     end
 
+    def viewmodel_base
+      ViewModelBase
+    end
+
+    def model_base
+      ApplicationRecord
+    end
+
     def model_class
       viewmodel_class.model_class
     end
@@ -32,11 +40,19 @@ module ViewModelSpecHelpers
     end
 
     def viewmodel_class
-      @viewmodel_class ||= define_viewmodel_class(:Model, spec: model_attributes, namespace: namespace)
+      @viewmodel_class ||= define_viewmodel_class(:Model,
+                                                  spec:           model_attributes,
+                                                  namespace:      namespace,
+                                                  viewmodel_base: viewmodel_base,
+                                                  model_base:     model_base)
     end
 
     def child_viewmodel_class
-      @child_viewmodel_class ||= define_viewmodel_class(:Child, spec: child_attributes, namespace: namespace)
+      @child_viewmodel_class ||= define_viewmodel_class(:Child,
+                                                        spec:           child_attributes,
+                                                        namespace:      namespace,
+                                                        viewmodel_base: viewmodel_base,
+                                                        model_base:     model_base)
     end
 
     def create_viewmodel!
@@ -68,6 +84,14 @@ module ViewModelSpecHelpers
       @builders << builder
       builder.viewmodel
     end
+
+    def subject_association
+      raise RuntimeError.new('Test model does not have a child association')
+    end
+
+    def subject_association_name
+      subject_association.association_name
+    end
   end
 
   module Single
@@ -94,6 +118,10 @@ module ViewModelSpecHelpers
       child_viewmodel_class
       super
     end
+
+    def subject_association
+      viewmodel_class._association_data('child')
+    end
   end
 
   module List
@@ -107,6 +135,10 @@ module ViewModelSpecHelpers
                     has_one :previous, class_name: self.name, foreign_key: :next_id, inverse_of: :next
                   },
                   viewmodel: ->(v) { association :next })
+    end
+
+    def subject_association
+      viewmodel_class._association_data('next')
     end
   end
 
@@ -133,6 +165,10 @@ module ViewModelSpecHelpers
       viewmodel_class
       super
     end
+
+    def subject_association
+      viewmodel_class._association_data('child')
+    end
   end
 
   module ParentAndHasManyChildren
@@ -158,6 +194,10 @@ module ViewModelSpecHelpers
       viewmodel_class
       super
     end
+
+    def subject_association
+      viewmodel_class._association_data('children')
+    end
   end
 
   module ParentAndSharedChild
@@ -182,6 +222,10 @@ module ViewModelSpecHelpers
     def viewmodel_class
       child_viewmodel_class
       super
+    end
+
+    def subject_association
+      viewmodel_class._association_data('child')
     end
   end
 
@@ -225,6 +269,10 @@ module ViewModelSpecHelpers
           end
           ModelChild
         end
+    end
+
+    def subject_association
+      viewmodel_class._association_data('children')
     end
   end
 end

--- a/test/unit/view_model/active_record/belongs_to_test.rb
+++ b/test/unit/view_model/active_record/belongs_to_test.rb
@@ -309,8 +309,8 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
     end
 
     def test_dependencies
-      root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent', 'something_else' => nil }])
-      assert_equal(DeepPreloader::Spec.new('label' => DeepPreloader::Spec.new), root_updates.first.preload_dependencies(ref_updates))
+      root_updates, _ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent', 'something_else' => nil }])
+      assert_equal(DeepPreloader::Spec.new('label' => DeepPreloader::Spec.new), root_updates.first.preload_dependencies)
       assert_equal({ 'something_else' => {} }, root_updates.first.updated_associations)
     end
 

--- a/test/unit/view_model/active_record/has_many_test.rb
+++ b/test/unit/view_model/active_record/has_many_test.rb
@@ -913,7 +913,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
 
     def test_dependencies
       root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent', 'something_else' => [] }])
-      assert_equal(DeepPreloader::Spec.new('children' => DeepPreloader::Spec.new), root_updates.first.preload_dependencies(ref_updates))
+      assert_equal(DeepPreloader::Spec.new('children' => DeepPreloader::Spec.new), root_updates.first.preload_dependencies)
       assert_equal({ 'something_else' => {} }, root_updates.first.updated_associations)
     end
 

--- a/test/unit/view_model/active_record/has_many_through_poly_test.rb
+++ b/test/unit/view_model/active_record/has_many_through_poly_test.rb
@@ -139,19 +139,19 @@ class ViewModel::ActiveRecord::HasManyThroughPolyTest < ActiveSupport::TestCase
     # TODO not part of ARVM; but depends on the particular context from #before_all
     # If we refactor out the contexts from their tests, this should go in another test file.
 
-    root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent' }])
+    root_updates, _ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent' }])
     assert_equal(DeepPreloader::Spec.new,
-                 root_updates.first.preload_dependencies(ref_updates),
+                 root_updates.first.preload_dependencies,
                  'nothing loaded by default')
 
-    root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent',
+    root_updates, _ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent',
                                                                                   'tags' => [{ '_ref' => 'r1' }] }],
                                                                                { 'r1' => { '_type' => 'TagB' } })
 
     assert_equal(DeepPreloader::Spec.new(
                   'parents_tags' => DeepPreloader::Spec.new(
                     'tag' => DeepPreloader::PolymorphicSpec.new)),
-                 root_updates.first.preload_dependencies(ref_updates),
+                 root_updates.first.preload_dependencies,
                  'mentioning tags causes through association loading, excluding shared')
   end
 
@@ -242,7 +242,7 @@ class ViewModel::ActiveRecord::HasManyThroughPolyTest < ActiveSupport::TestCase
     def test_dependencies
       root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent', 'something_else' => [] }])
       # Compare to non-polymorphic, which will also load the tags
-      deps = root_updates.first.preload_dependencies(ref_updates)
+      deps = root_updates.first.preload_dependencies
       assert_equal(DeepPreloader::Spec.new('parents_tags' => DeepPreloader::Spec.new('tag' => DeepPreloader::PolymorphicSpec.new)), deps)
       assert_equal({ 'something_else' => {} }, root_updates.first.updated_associations)
     end

--- a/test/unit/view_model/active_record/has_many_through_test.rb
+++ b/test/unit/view_model/active_record/has_many_through_test.rb
@@ -137,7 +137,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
 
     root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent' }])
     assert_equal(DeepPreloader::Spec.new,
-                 root_updates.first.preload_dependencies(ref_updates),
+                 root_updates.first.preload_dependencies,
                  'nothing loaded by default')
 
     root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes(
@@ -146,7 +146,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
       { 'r1' => { '_type' => 'Tag' } })
 
     assert_equal(DeepPreloader::Spec.new('parents_tags' => DeepPreloader::Spec.new('tag' => DeepPreloader::Spec.new)),
-                 root_updates.first.preload_dependencies(ref_updates),
+                 root_updates.first.preload_dependencies,
                  'mentioning tags and child_tags causes through association loading')
   end
 
@@ -614,7 +614,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
     def test_dependencies
       root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent', 'something_else' => [] }])
       assert_equal(DeepPreloader::Spec.new('parents_tags' => DeepPreloader::Spec.new('tag' => DeepPreloader::Spec.new)),
-                   root_updates.first.preload_dependencies(ref_updates))
+                   root_updates.first.preload_dependencies)
       assert_equal({ 'something_else' => {} }, root_updates.first.updated_associations)
     end
 
@@ -653,7 +653,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
     def test_preload_dependencies
       root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent' }])
       assert_equal(DeepPreloader::Spec.new,
-                   root_updates.first.preload_dependencies(ref_updates),
+                   root_updates.first.preload_dependencies,
                    'nothing loaded by default')
 
       root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes(
@@ -662,7 +662,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
         { 'r1' => { '_type' => 'Tag', 'child_tags' => [] } })
 
       assert_equal(DeepPreloader::Spec.new('parents_tags' => DeepPreloader::Spec.new('tag' => DeepPreloader::Spec.new)),
-                   root_updates.first.preload_dependencies(ref_updates),
+                   root_updates.first.preload_dependencies,
                    'mentioning tags and child_tags causes through association loading, excluding shared')
     end
 
@@ -677,7 +677,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
         { 'r1' => { '_type' => 'Tag', 'child_tags' => [] } })
 
       assert_equal(DeepPreloader::Spec.new('parents_tags' => DeepPreloader::Spec.new('tag' => DeepPreloader::Spec.new)),
-                   root_updates.first.preload_dependencies(ref_updates),
+                   root_updates.first.preload_dependencies,
                    'mentioning tags and child_tags in functional update value causes through association loading, ' \
                    'excluding shared')
 

--- a/test/unit/view_model/active_record/has_one_test.rb
+++ b/test/unit/view_model/active_record/has_one_test.rb
@@ -285,7 +285,7 @@ class ViewModel::ActiveRecord::HasOneTest < ActiveSupport::TestCase
 
     def test_dependencies
       root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent', 'something_else' => nil }])
-      assert_equal(DeepPreloader::Spec.new('target' => DeepPreloader::Spec.new), root_updates.first.preload_dependencies(ref_updates))
+      assert_equal(DeepPreloader::Spec.new('target' => DeepPreloader::Spec.new), root_updates.first.preload_dependencies)
       assert_equal({ 'something_else' => {} }, root_updates.first.updated_associations)
     end
 

--- a/test/unit/view_model/active_record/poly_test.rb
+++ b/test/unit/view_model/active_record/poly_test.rb
@@ -298,7 +298,7 @@ module ViewModel::ActiveRecord::PolyTest
 
       def test_dependencies
         root_updates, ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Parent', 'something_else' => nil }])
-        assert_equal(DeepPreloader::Spec.new('poly' => DeepPreloader::PolymorphicSpec.new), root_updates.first.preload_dependencies(ref_updates))
+        assert_equal(DeepPreloader::Spec.new('poly' => DeepPreloader::PolymorphicSpec.new), root_updates.first.preload_dependencies)
         assert_equal({ 'something_else' => {} }, root_updates.first.updated_associations)
       end
 

--- a/test/unit/view_model/traversal_context_test.rb
+++ b/test/unit/view_model/traversal_context_test.rb
@@ -1,0 +1,371 @@
+# frozen_string_literal: true
+
+
+require 'minitest/autorun'
+require 'minitest/unit'
+require 'minitest/hooks'
+
+require_relative '../../helpers/match_enumerator.rb'
+require_relative '../../helpers/arvm_test_utilities.rb'
+require_relative '../../helpers/arvm_test_models.rb'
+require_relative '../../helpers/viewmodel_spec_helpers.rb'
+
+require 'view_model'
+require 'view_model/record'
+
+class ViewModel::TraversalContextTest < ActiveSupport::TestCase
+  include ARVMTestUtilities
+  extend Minitest::Spec::DSL
+
+  # Use a on-entry callback to ensure that views are visited with the expected
+  # local TraversalContext in various flows
+  ContextDetail = Value.new(:parent_ref, :parent_association, :root)
+
+  class ContextRecorder
+    include ViewModel::Callbacks
+    attr_reader :details
+
+    # Views are identified by their ref (type/id): this means that for the
+    # purposes of these tests, new models must all have an id specified.
+    def initialize
+      @details = {}
+    end
+
+    # record information after_visit: allows id of new models to be established
+    after_visit do
+      ref = view.to_reference
+      raise RuntimeError.new('Visited twice') if details.has_key?(ref)
+      details[ref] = ContextDetail.new(
+        context.parent_viewmodel&.to_reference,
+        context.parent_association,
+        context.root?)
+    end
+  end
+
+  let(:vm) { create_viewmodel! }
+
+  let(:context_recorder) { ContextRecorder.new }
+
+  # Set up serialization and deserialization helpers to use the recording callback
+  def vm_serialize_context(viewmodel_class, **args)
+    viewmodel_class.new_serialize_context(callbacks: [context_recorder], **args)
+  end
+
+  def vm_deserialize_context(viewmodel_class, **args)
+    viewmodel_class.new_deserialize_context(callbacks: [context_recorder], **args)
+  end
+
+  def serialize(view, serialize_context: vm_serialize_context(view.class))
+    super(view, serialize_context: serialize_context)
+  end
+
+  def serialize_with_references(view, serialize_context: vm_serialize_context(view.class))
+    super(view, serialize_context: serialize_context)
+  end
+
+  # use `alter_by_view` to test deserialization: only override the deserialize_context
+  def alter_by_view!(vm_class, model,
+                     deserialize_context: vm_deserialize_context(vm_class),
+                     **args,
+                     &block)
+    super(vm_class, model, deserialize_context: deserialize_context, **args, &block)
+  end
+
+  module TraversalBehaviour
+    extend ActiveSupport::Concern
+    include Minitest::Hooks
+
+    def assert_traversal_matches(expected_details, recorded_details)
+      value(recorded_details.keys).must_contain_exactly(expected_details.keys)
+
+      recorded_details.each do |model_id, recorded_detail|
+        value(recorded_detail).must_equal(expected_details[model_id])
+      end
+    end
+
+    # Helpers to manipulate alter_by_view view hashes. Assumes that the test
+    # models have no more than one shared association, and if present it is the
+    # one under test.
+    def clear_subject_association(view, refs)
+      refs.clear if subject_association.shared?
+      view[subject_association_name] = subject_association.collection? ? [] : nil
+    end
+
+    def set_subject_association(view, refs, value)
+      if subject_association.shared?
+        refs.clear
+        value = convert_to_refs(refs, value)
+      end
+      view[subject_association_name] = value
+    end
+
+    def add_to_subject_association(view, refs, value)
+      if subject_association.shared?
+        value = convert_to_refs(refs, value)
+      end
+      view[subject_association_name] << value
+    end
+
+    def remove_from_subject_association(view, refs)
+      view[subject_association_name].reject! do |child|
+        if subject_association.shared?
+          ref = child[ViewModel::REFERENCE_ATTRIBUTE]
+          child = refs[ref]
+        end
+        match = yield(child)
+        if match && subject_association.shared?
+          refs.delete(ref)
+        end
+        match
+      end
+    end
+
+    def convert_to_refs(refs, value)
+      i = 0
+      ViewModel::Utils.map_one_or_many(value) do |v|
+        ref = "_child_ref_#{i += 1}"
+        refs[ref] = v
+        { ViewModel::REFERENCE_ATTRIBUTE => ref }
+      end
+    end
+  end
+
+  module BehavesLikeSerialization
+    extend ActiveSupport::Concern
+    include TraversalBehaviour
+    # requires :expected_parent_details, :expected_children_details
+
+    def self.included(base)
+      base.instance_eval do
+        it 'traverses as expected while serializing' do
+          serialize_with_references(vm)
+          expected = expected_parent_details.merge(expected_children_details)
+          assert_traversal_matches(expected, context_recorder.details)
+        end
+      end
+    end
+  end
+
+  module BehavesLikeDeserialization
+    extend ActiveSupport::Concern
+    include TraversalBehaviour
+    # requires
+    # :expected_parent_details, :expected_children_details
+    # :new_child_hash, :new_child_expected_details
+
+    def self.included(base)
+      base.instance_eval do
+        it 'traverses as expected while deserializing' do
+          alter_by_view!(viewmodel_class, vm.model) {}
+          expected = expected_parent_details.merge(expected_children_details)
+          assert_traversal_matches(expected, context_recorder.details)
+        end
+
+        it 'traverses as expected while clearing child(ren)' do
+          alter_by_view!(viewmodel_class, vm.model) do |view, refs|
+            clear_subject_association(view, refs)
+          end
+
+          expected = expected_parent_details
+          expected = expected.merge(expected_children_details) unless subject_association.shared?
+          assert_traversal_matches(expected, context_recorder.details)
+        end
+
+        it 'traverses as expected while replacing child(ren)' do
+          replacement = subject_association.collection? ? [new_child_hash] : new_child_hash
+
+          alter_by_view!(viewmodel_class, vm.model) do |view, refs|
+            set_subject_association(view, refs, replacement)
+          end
+
+          expected = expected_parent_details
+          expected = expected.merge(expected_children_details) unless subject_association.shared?
+          expected = expected.merge(new_child_expected_details)
+          assert_traversal_matches(expected, context_recorder.details)
+        end
+
+        it 'traverses as expected in replace_associated' do
+          ctx = vm_deserialize_context(viewmodel_class)
+          replacement = subject_association.collection? ? [new_child_hash] : new_child_hash
+          vm.replace_associated(subject_association_name, replacement, deserialize_context: ctx)
+
+          expected = expected_parent_details
+          expected = expected.merge(expected_children_details) unless subject_association.shared?
+          expected = expected.merge(new_child_expected_details)
+          assert_traversal_matches(expected, context_recorder.details)
+        end
+      end
+    end
+  end
+
+  module BehavesLikeCollectionDeserialization
+    extend ActiveSupport::Concern
+    include TraversalBehaviour
+
+    # requires :removed_child
+    def self.included(base)
+      base.instance_eval do
+        it 'traverses as expected when adding to children' do
+          alter_by_view!(viewmodel_class, vm.model) do |view, refs|
+            add_to_subject_association(view, refs, new_child_hash)
+          end
+
+          expected = expected_parent_details
+                       .merge(expected_children_details)
+                       .merge(new_child_expected_details)
+          assert_traversal_matches(expected, context_recorder.details)
+        end
+
+        it 'traverses as expected when removing from children' do
+          alter_by_view!(viewmodel_class, vm.model) do |view, refs|
+            remove_from_subject_association(view, refs) do |child|
+              child['id'] == removed_child.id
+            end
+          end
+
+          expected = expected_parent_details.merge(expected_children_details)
+          expected = expected.except(removed_child.to_reference) if subject_association.shared?
+          assert_traversal_matches(expected, context_recorder.details)
+        end
+
+        it 'traverses as expected in append_associated' do
+          ctx = vm_deserialize_context(viewmodel_class)
+          vm.append_associated(subject_association_name, [new_child_hash], deserialize_context: ctx)
+
+          expected = expected_parent_details.merge(new_child_expected_details)
+          assert_traversal_matches(expected, context_recorder.details)
+        end
+
+        it 'traverses as expected in delete_associated' do
+          ctx = vm_deserialize_context(viewmodel_class)
+          vm.delete_associated(subject_association_name, removed_child.id, deserialize_context: ctx)
+
+          expected = expected_parent_details
+          expected = expected.merge(removed_child_expected_details) unless subject_association.shared?
+          assert_traversal_matches(expected, context_recorder.details)
+        end
+      end
+    end
+  end
+
+  module BehavesLikeVisitor
+    def self.included(base)
+      base.instance_eval do
+        it 'traverses as expected while visiting' do
+          ViewModel::ActiveRecord::Visitor.new.visit(vm, context: vm_serialize_context(viewmodel_class))
+          expected = expected_parent_details.merge(expected_children_details)
+          assert_traversal_matches(expected, context_recorder.details)
+        end
+      end
+    end
+  end
+
+  # For each association type we want to make sure the traversal environment is
+  # as expected in every method of traversal.
+
+  let(:root_detail) { ContextDetail.new(nil, nil, true) }
+  let(:child_detail) do
+    if subject_association.shared?
+      root_detail
+    else
+      ContextDetail.new(vm.to_reference, subject_association_name, false)
+    end
+  end
+
+  let(:expected_parent_details) do
+    { vm.to_reference => root_detail }
+  end
+
+  let(:expected_children_details) do
+    children = {}
+    Array.wrap(vm.send(subject_association_name)).each do |child_vm|
+      children[child_vm.to_reference] = child_detail
+    end
+    children
+  end
+
+  before(:each) { expected_children_details }
+
+  let(:new_model) do
+    associated =
+      if subject_association.collection?
+        [child_model_class.new(name: 'b'), child_model_class.new(name: 'c')]
+      else
+        child_model_class.new(name: 'b')
+      end
+
+    model_class.new(name: 'a', subject_association_name => associated)
+  end
+
+  let(:new_child_id) { 9999 }
+  let(:new_child_ref) { ViewModel::Reference.new(child_viewmodel_class, new_child_id) }
+  let(:new_child_hash) do
+    {
+      '_type' => child_viewmodel_class.view_name,
+      'id'    => new_child_id,
+      '_new'  => true,
+      'name'  => 'z',
+    }
+  end
+
+  let(:new_child_expected_details) do
+    { new_child_ref => child_detail }
+  end
+
+  let(:removed_child) do
+    Array.wrap(vm.send(subject_association_name)).first
+  end
+
+  let(:removed_child_expected_details) do
+    { removed_child.to_reference => child_detail }
+  end
+
+  describe 'with parent and belongs to child' do
+    include ViewModelSpecHelpers::ParentAndBelongsToChild
+
+    include BehavesLikeSerialization
+    include BehavesLikeDeserialization
+    include BehavesLikeVisitor
+  end
+
+  describe 'with parent and has_one child' do
+    include ViewModelSpecHelpers::ParentAndBelongsToChild
+
+    include BehavesLikeSerialization
+    include BehavesLikeDeserialization
+    include BehavesLikeVisitor
+  end
+
+  describe 'with parent and has_many children' do
+    include ViewModelSpecHelpers::ParentAndHasManyChildren
+
+    include BehavesLikeSerialization
+    include BehavesLikeDeserialization
+    include BehavesLikeCollectionDeserialization
+    include BehavesLikeVisitor
+  end
+
+  describe 'with parent and shared child' do
+    include ViewModelSpecHelpers::ParentAndSharedChild
+
+    include BehavesLikeSerialization
+    include BehavesLikeDeserialization
+    include BehavesLikeVisitor
+  end
+
+  describe 'with parent and has-many-through children' do
+    include ViewModelSpecHelpers::ParentAndHasManyThroughChildren
+    let(:new_model) do
+      model_class.new(name: 'a',
+                      model_children: [
+                        join_model_class.new(child: child_model_class.new(name: 'b')),
+                        join_model_class.new(child: child_model_class.new(name: 'c')),
+                      ])
+    end
+
+    include BehavesLikeSerialization
+    include BehavesLikeDeserialization
+    include BehavesLikeCollectionDeserialization
+    include BehavesLikeVisitor
+  end
+end


### PR DESCRIPTION
We want to make sure that shared references are always visited in a clean root traversal context and owned references are always visited in child context with parent tree intact. Refactor a bit to achieve this and add tests for each association type.