### PR TITLE
CacheableView: Fix clearing cache of new models

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
 
 before_install:
   - gem update --system
+  - gem install bundler
 
 before_script:
   - psql -c 'CREATE DATABASE iknow_view_models;'

--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,3 +1,3 @@
 module IknowViewModels
-  VERSION = "2.4.1"
+  VERSION = "2.4.2"
 end

--- a/lib/view_model/active_record/cache/cacheable_view.rb
+++ b/lib/view_model/active_record/cache/cacheable_view.rb
@@ -48,7 +48,7 @@ module ViewModel::ActiveRecord::Cache::CacheableView
   # edited but the root is untouched.
   def before_deserialize(*)
     super
-    CacheClearer.new(self.class.viewmodel_cache, id).add_to_transaction
+    CacheClearer.new(self.class.viewmodel_cache, id).add_to_transaction unless new_model?
   end
 
   def destroy!(*)

--- a/lib/view_model/active_record/controller_base.rb
+++ b/lib/view_model/active_record/controller_base.rb
@@ -1,4 +1,4 @@
-require "iknow_params/parser"
+require 'iknow_params'
 
 class ViewModel::ActiveRecord
 module ControllerBase


### PR DESCRIPTION
This is a hard error with iknow_cache 1.1.1, since it will try to
clear the default id of `nil`.