### PR TITLE
Prerendering and nested controller improvements

### DIFF
--- a/lib/view_model/active_record/collection_nested_controller.rb
+++ b/lib/view_model/active_record/collection_nested_controller.rb
@@ -4,7 +4,7 @@ require 'view_model/active_record/nested_controller_base'
 # Contributes the following routes:
 # PUT    /parents/:parent_id/children            #append  -- deserialize (possibly existing) children and append to collection
 # POST   /parents/:parent_id/children            #replace -- deserialize (possibly existing) children, replacing existing collection
-# GET    /parents/:parent_id/children            #index   -- list collection
+# GET    /parents/:parent_id/children            #index_association -- list collection
 # DELETE /parents/:parent_id/children/:child_id  #disassociate -- delete relationship between parent/child (possibly garbage-collecting child)
 # DELETE /parents/:parent_id/children            #disassociate_all -- delete relationship from parent to all children
 
@@ -17,13 +17,8 @@ module ViewModel::ActiveRecord::CollectionNestedController
   extend ActiveSupport::Concern
   include ViewModel::ActiveRecord::NestedControllerBase
 
-  # List items associated with the owner
-  def index(scope: nil, serialize_context: new_serialize_context, &block)
-    if owner_viewmodel_id(required: false).nil?
-      super(scope: scope, serialize_context: serialize_context, &block)
-    else
-      show_association(scope: scope, serialize_context: serialize_context, &block)
-    end
+  def index_association(scope: nil, serialize_context: new_serialize_context)
+    show_association(scope: scope, serialize_context: serialize_context)
   end
 
   # Deserialize items of the associated type and associate them with the owner,

--- a/lib/view_model/active_record/collection_nested_controller.rb
+++ b/lib/view_model/active_record/collection_nested_controller.rb
@@ -1,10 +1,15 @@
+# frozen_string_literal: true
+
 require 'view_model/active_record/nested_controller_base'
-# Controller for accessing a ViewModel which is necessarily owned in a collection by a parent model.
+
+# Controller mixin for accessing a root ViewModel which can be accessed in a
+# collection by a parent model. Enabled by calling `nested_in :parent, as:
+# :children` on the viewmodel controller
 
 # Contributes the following routes:
 # PUT    /parents/:parent_id/children            #append  -- deserialize (possibly existing) children and append to collection
 # POST   /parents/:parent_id/children            #replace -- deserialize (possibly existing) children, replacing existing collection
-# GET    /parents/:parent_id/children            #index_association -- list collection
+# GET    /parents/:parent_id/children            #index_associated -- list collection
 # DELETE /parents/:parent_id/children/:child_id  #disassociate -- delete relationship between parent/child (possibly garbage-collecting child)
 # DELETE /parents/:parent_id/children            #disassociate_all -- delete relationship from parent to all children
 
@@ -17,7 +22,7 @@ module ViewModel::ActiveRecord::CollectionNestedController
   extend ActiveSupport::Concern
   include ViewModel::ActiveRecord::NestedControllerBase
 
-  def index_association(scope: nil, serialize_context: new_serialize_context)
+  def index_associated(scope: nil, serialize_context: new_serialize_context)
     show_association(scope: scope, serialize_context: serialize_context)
   end
 

--- a/lib/view_model/active_record/collection_nested_controller.rb
+++ b/lib/view_model/active_record/collection_nested_controller.rb
@@ -63,7 +63,7 @@ module ViewModel::ActiveRecord::CollectionNestedController
       ViewModel.preload_for_serialization(assoc_view, serialize_context: child_context)
       prerender_viewmodel(assoc_view, serialize_context: child_context)
     end
-    finish_render_viewmodel(pre_rendered)
+    render_json_string(pre_rendered)
     assoc_view
   end
 

--- a/lib/view_model/active_record/controller.rb
+++ b/lib/view_model/active_record/controller.rb
@@ -18,7 +18,7 @@ module ViewModel::ActiveRecord::Controller
       view = yield(view) if block_given?
       prerender_viewmodel(view, serialize_context: serialize_context)
     end
-    finish_render_viewmodel(pre_rendered)
+    render_json_string(pre_rendered)
     view
   end
 
@@ -29,7 +29,7 @@ module ViewModel::ActiveRecord::Controller
       views = yield(views) if block_given?
       prerender_viewmodel(views, serialize_context: serialize_context)
     end
-    finish_render_viewmodel(pre_rendered)
+    render_json_string(pre_rendered)
     views
   end
 
@@ -45,7 +45,7 @@ module ViewModel::ActiveRecord::Controller
       ViewModel.preload_for_serialization(view, serialize_context: serialize_context)
       prerender_viewmodel(view, serialize_context: serialize_context)
     end
-    finish_render_viewmodel(pre_rendered)
+    render_json_string(pre_rendered)
     view
   end
 

--- a/lib/view_model/active_record/controller.rb
+++ b/lib/view_model/active_record/controller.rb
@@ -1,4 +1,6 @@
 require 'view_model/active_record/controller_base'
+require 'view_model/active_record/collection_nested_controller'
+require 'view_model/active_record/singular_nested_controller'
 
 # Controller for accessing an ViewModel::ActiveRecord
 # Provides for the following routes:
@@ -10,6 +12,8 @@ require 'view_model/active_record/controller_base'
 module ViewModel::ActiveRecord::Controller
   extend ActiveSupport::Concern
   include ViewModel::ActiveRecord::ControllerBase
+  include ViewModel::ActiveRecord::CollectionNestedController
+  include ViewModel::ActiveRecord::SingularNestedController
 
   def show(scope: nil, serialize_context: new_serialize_context)
     view = nil
@@ -57,24 +61,6 @@ module ViewModel::ActiveRecord::Controller
     render_viewmodel(nil)
   end
 
-  class_methods do
-    def nested_in(owner, as:)
-      if as.to_s.singularize == as.to_s
-        include ViewModel::ActiveRecord::SingularNestedController
-      else
-        include ViewModel::ActiveRecord::CollectionNestedController
-      end
-
-      unless owner.is_a?(Class) && owner < ViewModel::Record
-        owner = ViewModel::Registry.for_view_name(owner.to_s.camelize)
-      end
-
-      self.owner_viewmodel = owner
-      raise ArgumentError.new("Could not find owner ViewModel class '#{owner_name}'") if owner_viewmodel.nil?
-      self.association_name = as
-    end
-  end
-
   included do
     etag { self.viewmodel.deep_schema_version }
   end
@@ -84,5 +70,4 @@ module ViewModel::ActiveRecord::Controller
   def viewmodel_id
     parse_param(:id)
   end
-
 end

--- a/lib/view_model/active_record/controller_base.rb
+++ b/lib/view_model/active_record/controller_base.rb
@@ -45,6 +45,10 @@ module ControllerBase
       @access_control
     end
 
+    def model_class
+      viewmodel.model_class
+    end
+
     protected
 
     def viewmodel_name=(name)
@@ -75,7 +79,7 @@ module ControllerBase
   end
 
   included do
-    delegate :viewmodel, :access_control, to: 'self.class'
+    delegate :viewmodel, :model_class, :access_control, to: 'self.class'
   end
 end
 end

--- a/lib/view_model/active_record/controller_base.rb
+++ b/lib/view_model/active_record/controller_base.rb
@@ -121,7 +121,10 @@ module ActionDispatch
                   get  '', action: :index          unless except.include?(:index)  || !add_shallow_routes
                 end
               end
-
+            else
+              collection do
+                get('', action: :index, as: '') unless except.include?(:index)
+              end
             end
           end
         end
@@ -138,12 +141,18 @@ module ActionDispatch
 
             name_route = { as: '' } # Only one route may take the name
 
-            post('',   action: :create_associated,  **name_route.extract!(:as)) unless except.include?(:create)
-            get('',    action: :show_associated,    **name_route.extract!(:as)) unless except.include?(:show)
-            delete('', action: :destroy_associated, **name_route.extract!(:as)) unless except.include?(:destroy)
+            if is_shallow
+              post('',   action: :create_associated,  **name_route.extract!(:as)) unless except.include?(:create)
+              get('',    action: :show_associated,    **name_route.extract!(:as)) unless except.include?(:show)
+              delete('', action: :destroy_associated, **name_route.extract!(:as)) unless except.include?(:destroy)
+            else
+              post('',   action: :create,  **name_route.extract!(:as)) unless except.include?(:create)
+              get('',    action: :show,    **name_route.extract!(:as)) unless except.include?(:show)
+              delete('', action: :destroy, **name_route.extract!(:as)) unless except.include?(:destroy)
+            end
           end
 
-          # nested singular resources provide collection accessors at the top level
+          # singularly nested resources provide collection accessors at the top level
           if is_shallow && add_shallow_routes
             resources resource_name.to_s.pluralize, shallow: true, only: [:show, :destroy] - except do
               shallow_scope do

--- a/lib/view_model/active_record/nested_controller_base.rb
+++ b/lib/view_model/active_record/nested_controller_base.rb
@@ -2,8 +2,6 @@ require 'view_model/active_record/controller_base'
 module ViewModel::ActiveRecord::NestedControllerBase
   extend ActiveSupport::Concern
 
-  protected
-
   def show_association(scope: nil, serialize_context: new_serialize_context)
     associated_views = nil
     pre_rendered = owner_viewmodel.transaction do
@@ -21,6 +19,8 @@ module ViewModel::ActiveRecord::NestedControllerBase
     render_json_string(pre_rendered)
     associated_views
   end
+
+  protected
 
   def write_association(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context)
     association_view = nil

--- a/lib/view_model/active_record/nested_controller_base.rb
+++ b/lib/view_model/active_record/nested_controller_base.rb
@@ -18,7 +18,7 @@ module ViewModel::ActiveRecord::NestedControllerBase
         prerender_viewmodel(associated_views, serialize_context: child_context)
       end
     end
-    finish_render_viewmodel(pre_rendered)
+    render_json_string(pre_rendered)
     associated_views
   end
 
@@ -37,7 +37,7 @@ module ViewModel::ActiveRecord::NestedControllerBase
       ViewModel.preload_for_serialization(association_view, serialize_context: child_context)
       prerender_viewmodel(association_view, serialize_context: child_context)
     end
-    finish_render_viewmodel(pre_rendered)
+    render_json_string(pre_rendered)
     association_view
   end
 

--- a/lib/view_model/active_record/singular_nested_controller.rb
+++ b/lib/view_model/active_record/singular_nested_controller.rb
@@ -2,7 +2,7 @@
 
 # Contributes the following routes:
 # POST   /parents/:parent_id/child   #create  -- deserialize (possibly existing) child, replacing existing child
-# GET    /parents/:parent_id/child   #show    -- show child of parent
+# GET    /parents/:parent_id/child   #show_association    -- show child of parent
 # DELETE /parents/:parent_id/child   #destroy -- delete relationship between parent and its child (possibly garbage-collecting child)
 
 ## Inherits the following routes to manipulate children directly:
@@ -16,15 +16,7 @@ module ViewModel::ActiveRecord::SingularNestedController
   include ViewModel::ActiveRecord::NestedControllerBase
 
   def index
-    raise ArgumentError.new("Index unavailable for nested view")
-  end
-
-  def show(serialize_context: new_serialize_context, &block)
-    if owner_viewmodel_id(required: false).nil?
-      super(serialize_context: serialize_context, &block)
-    else
-      show_association(serialize_context: serialize_context, &block)
-    end
+    raise ArgumentError.new('Index unavailable for nested view')
   end
 
   def create(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context)

--- a/lib/view_model/active_record/singular_nested_controller.rb
+++ b/lib/view_model/active_record/singular_nested_controller.rb
@@ -1,12 +1,17 @@
-# Controller for accessing a ViewModel which is necessarily owned in a collection by a parent model.
+# frozen_string_literal: true
+
+# Controller mixin for accessing a root ViewModel which can be accessed
+# individually by a parent model. Enabled by calling `nested_in :parent, as:
+# :child` on the viewmodel controller
 
 # Contributes the following routes:
-# POST   /parents/:parent_id/child   #create  -- deserialize (possibly existing) child, replacing existing child
-# GET    /parents/:parent_id/child   #show_association    -- show child of parent
-# DELETE /parents/:parent_id/child   #destroy -- delete relationship between parent and its child (possibly garbage-collecting child)
+# POST   /parents/:parent_id/child   #create_associated  -- deserialize (possibly existing) child, replacing existing child
+# GET    /parents/:parent_id/child   #show_associated    -- show child of parent
+# DELETE /parents/:parent_id/child   #destroy_associated -- delete relationship between parent and its child (possibly garbage-collecting child)
 
 ## Inherits the following routes to manipulate children directly:
 # POST   /children      #create -- create or update without parent
+# GET    /children      #index  -- list all child models regardless of parent
 # GET    /children/:id  #show
 # DELETE /children/:id  #destroy
 
@@ -15,23 +20,15 @@ module ViewModel::ActiveRecord::SingularNestedController
   extend ActiveSupport::Concern
   include ViewModel::ActiveRecord::NestedControllerBase
 
-  def index
-    raise ArgumentError.new('Index unavailable for nested view')
+  def show_associated(scope: nil, serialize_context: new_serialize_context, deserialize_context: new_deserialize_context)
+    show_association(scope: scope, serialize_context: serialize_context)
   end
 
-  def create(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context)
-    if owner_viewmodel_id(required: false).nil?
-      super(serialize_context: serialize_context, deserialize_context: deserialize_context)
-    else
-      write_association(serialize_context: serialize_context, deserialize_context: deserialize_context)
-    end
+  def create_associated(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context)
+    write_association(serialize_context: serialize_context, deserialize_context: deserialize_context)
   end
 
-  def destroy(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context)
-    if owner_viewmodel_id(required: false).nil?
-      super(serialize_context: serialize_context, deserialize_context: deserialize_context)
-    else
-      destroy_association(false, serialize_context: serialize_context, deserialize_context: deserialize_context)
-    end
+  def destroy_associated(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context)
+    destroy_association(false, serialize_context: serialize_context, deserialize_context: deserialize_context)
   end
 end

--- a/lib/view_model/controller.rb
+++ b/lib/view_model/controller.rb
@@ -40,10 +40,15 @@ module ViewModel::Controller
   # JSON string terminals. Useful for rendering cached views without parsing
   # then re-serializing the cached JSON.
   def render_json_view(json_view, json_references: {}, status: nil)
+    prerender = prerender_json_view(json_view, json_references: json_references)
+    finish_render_viewmodel(prerender, status: status)
+  end
+
+  def prerender_json_view(json_view, json_references: {})
     json_view = wrap_json_view(json_view)
     json_references = wrap_json_view(json_references)
 
-    response = Jbuilder.encode do |json|
+    Jbuilder.encode do |json|
       json.data json_view
       if json_references.present?
         json.references do
@@ -54,8 +59,6 @@ module ViewModel::Controller
       end
       yield(json) if block_given?
     end
-
-    render_json_string(response, status: status)
   end
 
   def render_error(error_view, status = 500)

--- a/lib/view_model/controller.rb
+++ b/lib/view_model/controller.rb
@@ -13,9 +13,10 @@ module ViewModel::Controller
 
   def render_viewmodel(viewmodel, status: nil, serialize_context: viewmodel.class.try(:new_serialize_context), &block)
     prerender = prerender_viewmodel(viewmodel, serialize_context: serialize_context, &block)
-    finish_render_viewmodel(prerender, status: status)
+    render_json_string(prerender, status: status)
   end
 
+  # Render viewmodel(s) to a JSON API response as a String
   def prerender_viewmodel(viewmodel, status: nil, serialize_context: viewmodel.class.try(:new_serialize_context))
     Jbuilder.encode do |json|
       json.data do
@@ -32,16 +33,12 @@ module ViewModel::Controller
     end
   end
 
-  def finish_render_viewmodel(pre_rendered, status: nil)
-    render_json_string(pre_rendered, status: status)
-  end
-
   # Render an arbitrarily nested tree of hashes and arrays with pre-rendered
   # JSON string terminals. Useful for rendering cached views without parsing
   # then re-serializing the cached JSON.
   def render_json_view(json_view, json_references: {}, status: nil)
     prerender = prerender_json_view(json_view, json_references: json_references)
-    finish_render_viewmodel(prerender, status: status)
+    render_json_string(prerender, status: status)
   end
 
   def prerender_json_view(json_view, json_references: {})
@@ -115,7 +112,7 @@ module ViewModel::Controller
     render_json_string(response, status: status)
   end
 
-  def render_json_string(response, status:)
+  def render_json_string(response, status: nil)
     render(json: response, status: status)
   end
 

--- a/lib/view_model/controller.rb
+++ b/lib/view_model/controller.rb
@@ -36,8 +36,8 @@ module ViewModel::Controller
   # Render an arbitrarily nested tree of hashes and arrays with pre-rendered
   # JSON string terminals. Useful for rendering cached views without parsing
   # then re-serializing the cached JSON.
-  def render_json_view(json_view, json_references: {}, status: nil)
-    prerender = prerender_json_view(json_view, json_references: json_references)
+  def render_json_view(json_view, json_references: {}, status: nil, &block)
+    prerender = prerender_json_view(json_view, json_references: json_references, &block)
     render_json_string(prerender, status: status)
   end
 

--- a/test/unit/view_model/active_record/controller_test.rb
+++ b/test/unit/view_model/active_record/controller_test.rb
@@ -183,8 +183,19 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
 
   #### Controller for nested model
 
-  def test_nested_collection_index
+  def test_nested_collection_index_associated
     childcontroller = ChildController.new(parent_id: @parent.id)
+
+    childcontroller.invoke(:index_association)
+
+    assert_equal(200, childcontroller.status)
+
+    assert_equal({ 'data' => @parent.children.map { |c| ChildView.new(c).to_hash } },
+                 childcontroller.hash_response)
+  end
+
+  def test_nested_collection_index
+    childcontroller = ChildController.new
 
     childcontroller.invoke(:index)
 
@@ -352,8 +363,8 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
   def test_nested_singular_show_from_parent
     old_label = @parent.label
 
-    labelcontroller = LabelController.new(parent_id: @parent.id, label_id: old_label.id)
-    labelcontroller.invoke(:show)
+    labelcontroller = LabelController.new(parent_id: @parent.id)
+    labelcontroller.invoke(:show_association)
 
     assert_equal(200, labelcontroller.status, labelcontroller.hash_response)
 
@@ -395,7 +406,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
   def test_nested_singular_show_from_id
     old_label = @parent.label
 
-    labelcontroller = LabelController.new(parent_id: @parent.id, label_id: old_label.id)
+    labelcontroller = LabelController.new(id: old_label.id)
     labelcontroller.invoke(:show)
 
     assert_equal(200, labelcontroller.status, labelcontroller.hash_response)

--- a/test/unit/view_model/active_record/controller_test.rb
+++ b/test/unit/view_model/active_record/controller_test.rb
@@ -186,7 +186,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
   def test_nested_collection_index_associated
     childcontroller = ChildController.new(parent_id: @parent.id)
 
-    childcontroller.invoke(:index_association)
+    childcontroller.invoke(:index_associated)
 
     assert_equal(200, childcontroller.status)
 
@@ -344,7 +344,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
 
     data = {'_type' => 'Label', 'text' => 'new label'}
     labelcontroller = LabelController.new(parent_id: @parent.id, data: data)
-    labelcontroller.invoke(:create)
+    labelcontroller.invoke(:create_associated)
 
     assert_equal(200, labelcontroller.status, labelcontroller.hash_response)
 
@@ -364,7 +364,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     old_label = @parent.label
 
     labelcontroller = LabelController.new(parent_id: @parent.id)
-    labelcontroller.invoke(:show_association)
+    labelcontroller.invoke(:show_associated)
 
     assert_equal(200, labelcontroller.status, labelcontroller.hash_response)
 
@@ -375,8 +375,8 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
   def test_nested_singular_destroy_from_parent
     old_label = @parent.label
 
-    labelcontroller = LabelController.new(parent_id: @parent.id, label_id: old_label.id)
-    labelcontroller.invoke(:destroy)
+    labelcontroller = LabelController.new(parent_id: @parent.id)
+    labelcontroller.invoke(:destroy_associated)
 
     @parent.reload
 
@@ -387,12 +387,12 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     assert_predicate(Label.where(id: old_label.id), :empty?)
   end
 
-  def test_nested_singular_update
+  def test_nested_singular_update_from_parent
     old_label = @parent.label
 
     data = {'_type' => 'Label', 'id' => old_label.id, 'text' => 'new label'}
-    labelcontroller = LabelController.new(data: data)
-    labelcontroller.invoke(:create)
+    labelcontroller = LabelController.new(parent_id: @parent.id, data: data)
+    labelcontroller.invoke(:create_associated)
 
     assert_equal(200, labelcontroller.status, labelcontroller.hash_response)
 
@@ -432,5 +432,20 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     assert_predicate(Target.where(id: old_target.id), :empty?)
   end
 
+  def test_nested_singular_update
+    old_label = @parent.label
+
+    data = {'_type' => 'Label', 'id' => old_label.id, 'text' => 'new label'}
+    labelcontroller = LabelController.new(data: data)
+    labelcontroller.invoke(:create)
+
+    assert_equal(200, labelcontroller.status, labelcontroller.hash_response)
+
+    old_label.reload
+
+    assert_equal('new label', old_label.text)
+    assert_equal({ 'data' => LabelView.new(old_label).to_hash },
+                 labelcontroller.hash_response)
+  end
 
 end


### PR DESCRIPTION
Offers a prerendering version of render_json_view
Tidies up prerendering interface to make it clearer that what's produced is a JSON-encoded string body
Separates controller actions for nested controllers: nested routes now call `x_associated` rather than calling `x` and dispatching internally after sniffing parameters.
Moves nested controller behaviour into ViewModel::Controller rather than dynamically `include`ing from the `nested_in` call.
These changes make it possible to independently override each behaviour.