### PR TITLE
Allow the viewmodel cache to depend on an external group

### DIFF
--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -261,8 +261,9 @@ class ViewModel::ActiveRecord < ViewModel::Record
         end
     end
 
-    def cacheable!
+    def cacheable!(**opts)
       include ViewModel::ActiveRecord::Cache::CacheableView
+      create_viewmodel_cache!(**opts)
     end
 
     # internal

--- a/lib/view_model/active_record/cache/cacheable_view.rb
+++ b/lib/view_model/active_record/cache/cacheable_view.rb
@@ -21,17 +21,13 @@ module ViewModel::ActiveRecord::Cache::CacheableView
     end
   end
 
-  included do
-    @viewmodel_cache = ViewModel::ActiveRecord::Cache.new(self)
-  end
-
   class_methods do
-    def viewmodel_cache
-      @viewmodel_cache
+    def create_viewmodel_cache!(**opts)
+      @viewmodel_cache = ViewModel::ActiveRecord::Cache.new(self, **opts)
     end
 
-    def specialize_cache!(name, prune: nil, include: nil)
-      viewmodel_cache.add_specialization(name, prune: prune, include: include)
+    def viewmodel_cache
+      @viewmodel_cache
     end
 
     def serialize_from_cache(views, serialize_context:)

--- a/test/unit/view_model/active_record/cache_test.rb
+++ b/test/unit/view_model/active_record/cache_test.rb
@@ -80,8 +80,9 @@ class ViewModel::ActiveRecord
     end
 
     # Extract the iKnowCaches to verify their contents
-    def cache_for(viewmodel)
-      viewmodel.viewmodel_cache.send(:cache_specialization_for, viewmodel.new_serialize_context)
+    def read_cache(viewmodel_class, id)
+      vm_cache = viewmodel_class.viewmodel_cache
+      vm_cache.send(:cache).read(vm_cache.key_for(id))
     end
 
     def serialize_from_database
@@ -120,12 +121,12 @@ class ViewModel::ActiveRecord
         end
 
         it 'writes to the cache after fetching' do
-          cached_value = cache_for(viewmodel_class).read({ id: root.id })
+          cached_value = read_cache(viewmodel_class, root.id)
           value(cached_value).wont_be(:present?)
 
           fetch_with_cache
 
-          cached_value = cache_for(viewmodel_class).read({ id: root.id })
+          cached_value = read_cache(viewmodel_class, root.id)
           value(cached_value).must_be(:present?)
         end
 
@@ -133,7 +134,7 @@ class ViewModel::ActiveRecord
           data, refs = fetch_with_cache
           value(data.size).must_equal(1)
 
-          cached_root = cache_for(viewmodel_class).read({ id: root.id })
+          cached_root = read_cache(viewmodel_class, root.id)
           value(cached_root).must_be(:present?)
           value(cached_root[:data]).must_equal(data.first)
 
@@ -155,7 +156,7 @@ class ViewModel::ActiveRecord
             # cached.
             next unless view_name == "Shared"
             value(id).must_equal(shared.id)
-            cached_shared = cache_for(shared_viewmodel_class).read({ id: id })
+            cached_shared = read_cache(shared_viewmodel_class, id)
             value(cached_shared).must_be(:present?)
             value(cached_shared[:data]).must_equal(ref_data)
             value(cached_shared[:ref_cache]).must_be(:blank?)


### PR DESCRIPTION
When there are multiple views on a single model, they must mutually invalidate. Presently the cache is entirely internal and unique per viewmodel. The two approaches that come to mind are as follows.

### [A] All cachable models must provide the cache

Which means an extra restriction that whenever you include `ViewModel::ActiveRecord::Cache`, you must also define a cache getter on the model. Failing to define the cache getter will explode at load time. :+1: 

### [B] Let the user specify the cache when necessary (this PR)

Less disruptive and backwards compatible. Lets you use the defaults when you only have a single cache, and doesn't expose the details of the caching libray. But it seems a bit like a loaded foot gun. Any failure to override the method, like a simple typo, and the cache defaults to the internal cache.