### PR TITLE
No longer support resolving previous parent from out of tree

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,3 +1,3 @@
 module IknowViewModels
-  VERSION = "2.6.3"
+  VERSION = "2.7.0"
 end

--- a/lib/view_model/deserialization_error.rb
+++ b/lib/view_model/deserialization_error.rb
@@ -226,7 +226,7 @@ class ViewModel
 
     class ParentNotFound < NotFound
       def detail
-        "Could not resolve previous parents for the following referenced viewmodels: " +
+        "Could not resolve release from previous parent for the following owned viewmodel(s): " +
           nodes.map(&:to_s).join(", ")
       end
     end

--- a/test/unit/view_model/active_record/belongs_to_test.rb
+++ b/test/unit/view_model/active_record/belongs_to_test.rb
@@ -182,20 +182,6 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
     assert(Label.where(id: old_p2_label).blank?, 'p2 old label deleted')
   end
 
-  def test_belongs_to_move_and_replace_from_outside_tree
-    old_p1_label = @parent1.label
-
-    assert_raises(ViewModel::DeserializationError::ParentNotFound) do
-      set_by_view!(ParentView, @parent2) do |p2, refs|
-        p2['label'] = update_hash_for(LabelView, old_p1_label)
-      end
-    end
-
-    # For now, we don't allow moving unless the pointer is from child to parent,
-    # as it's more involved to safely resolve the old parent in the other
-    # direction.
-  end
-
   def test_belongs_to_swap
     old_p1_label = @parent1.label
     old_p2_label = @parent2.label


### PR DESCRIPTION
The feature was unused, fragile, and makes future improvements such as owned associations to roots harder.

Continue supporting edit checks on previous parents with `append_associated`, which is driven at the level of the children.