### PR TITLE
Record tree changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ gem 'acts_as_manual_list',      git: 'https://github.com/iknow/acts_as_manual_li
 gem 'deep_preloader',           git: 'https://github.com/iknow/deep_preloader',      branch: 'master'
 gem 'iknow_cache',              git: 'https://github.com/iknow/iknow_cache',         branch: 'master'
 gem 'iknow_params', '~> 2.2.0', git: 'https://github.com/iknow/iknow_params',        branch: 'master'
+gem 'keyword_builder',          git: 'https://github.com/iknow/keyword_builder',     branch: 'master'
 gem 'safe_values',              git: 'https://github.com/iknow/safe_values',         branch: 'master'

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -8,6 +8,7 @@ gem "acts_as_manual_list", git: "https://github.com/iknow/acts_as_manual_list", 
 gem "deep_preloader", git: "https://github.com/iknow/deep_preloader", branch: "master"
 gem "iknow_cache", git: "https://github.com/iknow/iknow_cache", branch: "master"
 gem "iknow_params", "~> 2.2.0", git: "https://github.com/iknow/iknow_params", branch: "master"
+gem "keyword_builder", git: "https://github.com/iknow/keyword_builder", branch: "master"
 gem "safe_values", git: "https://github.com/iknow/safe_values", branch: "master"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -8,6 +8,7 @@ gem "acts_as_manual_list", git: "https://github.com/iknow/acts_as_manual_list", 
 gem "deep_preloader", git: "https://github.com/iknow/deep_preloader", branch: "master"
 gem "iknow_cache", git: "https://github.com/iknow/iknow_cache", branch: "master"
 gem "iknow_params", "~> 2.2.0", git: "https://github.com/iknow/iknow_params", branch: "master"
+gem "keyword_builder", git: "https://github.com/iknow/keyword_builder", branch: "master"
 gem "safe_values", git: "https://github.com/iknow/safe_values", branch: "master"
 
 gemspec path: "../"

--- a/iknow_view_models.gemspec
+++ b/iknow_view_models.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "iknow_cache"
   spec.add_dependency "iknow_params"
   spec.add_dependency "safe_values"
+  spec.add_dependency "keyword_builder"
 
   spec.add_dependency "concurrent-ruby"
   spec.add_dependency "jbuilder"

--- a/iknow_view_models.gemspec
+++ b/iknow_view_models.gemspec
@@ -44,5 +44,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pg", '~> 0.18' # As of 5.1.4, Rails runtime check excludes pg 1.x, see #31669
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec-expectations"
   spec.add_development_dependency "sqlite3"
 end

--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,3 +1,3 @@
 module IknowViewModels
-  VERSION = "2.7.1"
+  VERSION = "2.8.0"
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -273,6 +273,7 @@ class ViewModel
   end
 end
 
+require 'view_model/config'
 require 'view_model/utils'
 require 'view_model/error'
 require 'view_model/callbacks'

--- a/lib/view_model/active_record/visitor.rb
+++ b/lib/view_model/active_record/visitor.rb
@@ -45,7 +45,7 @@ class ViewModel::ActiveRecord::Visitor
 
     if for_edit
       view_changes = changes(view)
-      run_callback(ViewModel::Callbacks::Hook::OnChange, view, context: context, changes: view_changes) if view_changes
+      run_callback(ViewModel::Callbacks::Hook::OnChange, view, context: context, changes: view_changes) if view_changes.changed?
       run_callback(ViewModel::Callbacks::Hook::AfterDeserialize, view, context: context, changes: view_changes)
     end
 
@@ -69,8 +69,9 @@ class ViewModel::ActiveRecord::Visitor
   end
 
   # This method may be overridden by subclasses to specify the changes to be
-  # provided to callback hooks for each view. By default returns nil.
+  # provided to callback hooks for each view. By default returns an empty
+  # Changes.
   def changes(_view)
-    nil
+    ViewModel::Changes.new
   end
 end

--- a/lib/view_model/changes.rb
+++ b/lib/view_model/changes.rb
@@ -1,16 +1,21 @@
-require "view_model/utils/collections"
+# frozen_string_literal: true
+
+require 'view_model/utils/collections'
+
 class ViewModel::Changes
   using ViewModel::Utils::Collections
 
-  attr_reader :new, :changed_attributes, :changed_associations, :deleted
+  attr_reader :new, :changed_attributes, :changed_associations, :changed_children, :deleted
 
   alias new? new
   alias deleted? deleted
+  alias changed_children? changed_children
 
-  def initialize(new: false, changed_attributes: [], changed_associations: [], deleted: false)
+  def initialize(new: false, changed_attributes: [], changed_associations: [], changed_children: false, deleted: false)
     @new                  = new
     @changed_attributes   = changed_attributes.map(&:to_s)
     @changed_associations = changed_associations.map(&:to_s)
+    @changed_children     = changed_children
     @deleted              = deleted
   end
 
@@ -25,12 +30,21 @@ class ViewModel::Changes
       attributes.any? { |attr| changed_attributes.include?(attr.to_s) }
   end
 
+  def changed?
+    new? || deleted? || changed_attributes.present? || changed_associations.present?
+  end
+
+  def changed_tree?
+    changed? || changed_children?
+  end
+
   def to_h
     {
-      "changed_attributes"   => changed_attributes.dup,
-      "changed_associations" => changed_associations.dup,
-      "new"                  => new?,
-      "deleted"              => deleted?,
+      'changed_attributes'   => changed_attributes.dup,
+      'changed_associations' => changed_associations.dup,
+      'new'                  => new?,
+      'changed_children'     => changed_children?,
+      'deleted'              => deleted?,
     }
   end
 
@@ -38,9 +52,10 @@ class ViewModel::Changes
     return false unless other.is_a?(ViewModel::Changes)
 
     self.new? == other.new? &&
+      self.changed_children? == other.changed_children? &&
+      self.deleted? == other.deleted? &&
       self.changed_attributes.contains_exactly?(other.changed_attributes) &&
-      self.changed_associations.contains_exactly?(other.changed_associations) &&
-      self.deleted? == other.deleted?
+      self.changed_associations.contains_exactly?(other.changed_associations)
   end
 
   alias eql? ==

--- a/lib/view_model/config.rb
+++ b/lib/view_model/config.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'safe_values'
+require 'keyword_builder'
+
+ViewModel::Config = Value.new(
+  show_cause_in_error_view: false,
+)
+
+class ViewModel::Config
+  def self.configure!(&block)
+    if instance_variable_defined?(:@instance)
+      raise ArgumentError.new('ViewModel library already configured')
+    end
+
+    builder = KeywordBuilder.create(self, constructor: :with)
+    @instance = builder.build!(&block)
+  end
+
+  def self._option(opt)
+    configure! unless instance_variable_defined?(:@instance)
+    @instance[opt]
+  end
+
+  self.members.each do |opt|
+    define_singleton_method(opt) { _option(opt) }
+  end
+end

--- a/lib/view_model/deserialization_error.rb
+++ b/lib/view_model/deserialization_error.rb
@@ -275,6 +275,19 @@ class ViewModel
       end
     end
 
+    class InvalidParentEdit < DeserializationError
+      def initialize(changes, node)
+        @changes = changes
+        super([node])
+      end
+
+      detail 'Illegal edit to parent during external association update'
+
+      def meta
+        super.merge(changes: @changes.to_h)
+      end
+    end
+
     # Optimistic lock failure updating nodes
     class LockFailure < DeserializationError
       status 400

--- a/lib/view_model/error_view.rb
+++ b/lib/view_model/error_view.rb
@@ -25,7 +25,7 @@ class ViewModel::ErrorView < ViewModel::Record
 
   # Ruby exceptions should never be serialized in production
   def serialize_exception(json, serialize_context:)
-    super unless Rails.env == 'production'
+    super if ViewModel::Config.show_cause_in_error_view
   end
 
   # Only serialize causes for aggregation errors.

--- a/lib/view_model/test_helpers.rb
+++ b/lib/view_model/test_helpers.rb
@@ -3,6 +3,7 @@
 module ViewModel::TestHelpers
   require 'view_model/test_helpers/arvm_builder'
   extend ActiveSupport::Concern
+  using ViewModel::Utils::Collections
 
   def serialize_with_references(serializable, serialize_context: ViewModel.new_serialize_context)
     data = ViewModel.serialize_to_hash(serializable, serialize_context: serialize_context)
@@ -92,7 +93,11 @@ module ViewModel::TestHelpers
       else
         assert_model_represents_database(association.target, been_there: been_there)
       end
-
     end
+  end
+
+  def assert_contains_exactly(expected, actual, msg = nil)
+    msg ||= diff(expected, actual)
+    assert(expected.contains_exactly?(actual), msg)
   end
 end

--- a/lib/view_model/utils.rb
+++ b/lib/view_model/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ViewModel::Utils
   class << self
     def wrap_one_or_many(obj)

--- a/lib/view_model/utils/collections.rb
+++ b/lib/view_model/utils/collections.rb
@@ -1,21 +1,26 @@
+# frozen_string_literal: true
+
 class ViewModel::Utils
   module Collections
     def self.count_by(enumerable)
-      enumerable.each_with_object(Hash.new(0)) do |el, counts|
-        key         = yield(el)
-        counts[key] += 1 unless key.nil?
+      enumerable.each_with_object({}) do |el, counts|
+        key = yield(el)
+
+        unless key.nil?
+          counts[key] = (counts[key] || 0) + 1
+        end
       end
     end
 
     refine Array do
       def contains_exactly?(other)
-        vals = to_set
-        other.each { |o| return false unless vals.delete?(o) }
-        vals.blank?
+        mine   = count_by { |x| x }
+        theirs = other.count_by { |x| x }
+        mine == theirs
       end
 
       def count_by(&by)
-        Collections::count_by(self, &by)
+        Collections.count_by(self, &by)
       end
 
       def duplicates_by(&by)
@@ -29,7 +34,7 @@ class ViewModel::Utils
 
     refine Hash do
       def count_by(&by)
-        Collections::count_by(self, &by)
+        Collections.count_by(self, &by)
       end
 
       def duplicates_by(&by)

--- a/test/helpers/arvm_test_models.rb
+++ b/test/helpers/arvm_test_models.rb
@@ -37,7 +37,7 @@ class ViewModelBase < ViewModel::ActiveRecord
       super(**params)
     end
 
-    delegate :visible_checks, :editable_checks, :valid_edit_refs, :valid_edit_changes, :all_valid_edit_changes, to: :access_control
+    delegate :visible_checks, :editable_checks, :valid_edit_refs, :valid_edit_changes, :all_valid_edit_changes, :was_edited?, to: :access_control
   end
 
   def self.deserialize_context_class

--- a/test/helpers/arvm_test_utilities.rb
+++ b/test/helpers/arvm_test_utilities.rb
@@ -11,6 +11,7 @@ ActiveSupport::TestCase.include(Minitest::Hooks)
 module ARVMTestUtilities
   extend ActiveSupport::Concern
   include ViewModel::TestHelpers
+  using ViewModel::Utils::Collections
 
   def self.included(klass)
     klass.include(QueryLogging)
@@ -79,14 +80,11 @@ module ARVMTestUtilities
   end
 
   def count_all(enum)
-    # equivalent to `group_by{|x|x}.map{|k,v| [k, v.length]}.to_h`
-    enum.each_with_object(Hash.new(0)) do |x, counts|
-      counts[x] += 1
-    end
+    enum.count_by { |x| x }
   end
 
   def enable_logging!
-    if ENV["DEBUG"]
+    if ENV['DEBUG']
       ActiveRecord::Base.logger = Logger.new(STDERR)
     end
   end

--- a/test/helpers/callback_tracer.rb
+++ b/test/helpers/callback_tracer.rb
@@ -3,7 +3,11 @@
 class CallbackTracer
   include ViewModel::Callbacks
 
-  Visit = Struct.new(:hook, :view)
+  Visit = Struct.new(:hook, :view) do
+    def inspect
+      "#{hook.name}(#{view.to_reference})"
+    end
+  end
 
   attr_reader :hook_trace
 

--- a/test/helpers/test_access_control.rb
+++ b/test/helpers/test_access_control.rb
@@ -49,4 +49,8 @@ class TestAccessControl < ViewModel::AccessControl
       .select { | cref, _changes| cref == ref }
       .map    { |_cref,  changes| changes }
   end
+
+  def was_edited?(ref)
+    all_valid_edit_changes(ref).present?
+  end
 end

--- a/test/unit/view_model/active_record/belongs_to_test.rb
+++ b/test/unit/view_model/active_record/belongs_to_test.rb
@@ -195,7 +195,6 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
     assert_equal(old_p1_label, @parent2.label, 'p2 has label from p1')
   end
 
-
   def test_moved_child_is_not_delete_checked
     # move from p1 to p3
     d_context = ParentView.new_deserialize_context

--- a/test/unit/view_model/active_record/controller_test.rb
+++ b/test/unit/view_model/active_record/controller_test.rb
@@ -26,14 +26,16 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     hook_nesting = []
 
     trace.each_with_index do |t, i|
-      case t.hook.name
-      when /^On/
+      case t.hook
+      when ViewModel::Callbacks::Hook::OnChange,
+           ViewModel::Callbacks::Hook::BeforeValidate
         # ignore
-
-      when /^Before/
+      when ViewModel::Callbacks::Hook::BeforeVisit,
+           ViewModel::Callbacks::Hook::BeforeDeserialize
         hook_nesting.push([t, i])
 
-      when /^After/
+      when ViewModel::Callbacks::Hook::AfterVisit,
+           ViewModel::Callbacks::Hook::AfterDeserialize
         (nested_top, nested_index) = hook_nesting.pop
 
         unless nested_top.hook.name == t.hook.name.sub(/^After/, 'Before')

--- a/test/unit/view_model/active_record/has_one_test.rb
+++ b/test/unit/view_model/active_record/has_one_test.rb
@@ -119,9 +119,7 @@ class ViewModel::ActiveRecord::HasOneTest < ActiveSupport::TestCase
       deserialize_context: deserialize_context)
 
     assert_equal(Set.new([ViewModel::Reference.new(ParentView, @parent1.id),
-                          ViewModel::Reference.new(ParentView, @parent2.id),
-                          ViewModel::Reference.new(TargetView, t1.id),
-                          ViewModel::Reference.new(TargetView, t2.id)]),
+                          ViewModel::Reference.new(ParentView, @parent2.id)]),
                  deserialize_context.valid_edit_refs.to_set)
 
     @parent1.reload

--- a/test/unit/view_model/active_record/shared_test.rb
+++ b/test/unit/view_model/active_record/shared_test.rb
@@ -240,17 +240,16 @@ class ViewModel::ActiveRecord::SharedTest < ActiveSupport::TestCase
   end
 
   def test_child_change_editchecks_parent
-    serialize_context = ParentView.new_serialize_context(include: :category)
-    d_context = ParentView.new_deserialize_context
+    s_context = ParentView.new_serialize_context(include: :category)
 
-    alter_by_view!(ParentView, @parent1, serialize_context: serialize_context, deserialize_context: d_context) do |view, refs|
+    nv, d_context = alter_by_view!(ParentView, @parent1, serialize_context: s_context) do |view, refs|
       refs.delete(view['category']['_ref'])
       view['category']['_ref'] = 'new_cat'
-      refs['new_cat'] = { "_type" => "Category", "name" => "new category"}
+      refs['new_cat'] = { '_type' => 'Category', 'name' => 'new category' }
     end
 
-    assert(d_context.valid_edit_refs.include?(ViewModel::Reference.new(CategoryView, nil)))
-    assert(d_context.valid_edit_refs.include?(ViewModel::Reference.new(ParentView, @parent1.id)))
+    assert(d_context.valid_edit_refs.include?(nv.to_reference))
+    assert(d_context.valid_edit_refs.include?(nv.category.to_reference))
   end
 
   def test_child_delete_editchecks_parent

--- a/test/unit/view_model/active_record_test.rb
+++ b/test/unit/view_model/active_record_test.rb
@@ -28,8 +28,10 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
       end
 
       define_model do
-        validates :name, exclusion: {in: %w(invalid),
-                                     message: 'invalid due to matching test sentinel' }
+        validates :name, exclusion: {
+                    in: %w[invalid],
+                    message: 'invalid due to matching test sentinel',
+                  }
       end
 
       define_viewmodel do
@@ -149,15 +151,17 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
   def test_editability_checks_create
     context = ViewModelBase.new_deserialize_context
-    ParentView.deserialize_from_view({'_type' => 'Parent', 'name' => 'p'},
-                                        deserialize_context: context)
-    assert_equal([ViewModel::Reference.new(ParentView, nil)], context.valid_edit_refs)
+    pv = ParentView.deserialize_from_view({ '_type' => 'Parent', 'name' => 'p' },
+                                          deserialize_context: context)
+
+    assert_equal([pv.to_reference],
+                 context.valid_edit_refs)
   end
 
   def test_editability_checks_create_on_empty_record
     context = ViewModelBase.new_deserialize_context
     TrivialView.deserialize_from_view({'_type' => 'Trivial' },
-                                     deserialize_context: context)
+                                      deserialize_context: context)
 
     ref = ViewModel::Reference.new(TrivialView, nil)
     assert_equal([ref], context.valid_edit_refs)
@@ -168,7 +172,6 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
     assert_empty(changes.changed_associations)
     assert_equal(false, changes.deleted?)
   end
-
 
   def test_editability_raises
     no_edit_context = ViewModelBase.new_deserialize_context(can_edit: false)

--- a/test/unit/view_model/callbacks_test.rb
+++ b/test/unit/view_model/callbacks_test.rb
@@ -70,10 +70,14 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
         value(callback.hook_trace).must_equal(
           [visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm),
+
            visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm.child),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm.child),
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm.child),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm.child),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm.child),
+
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm)])
       end
@@ -85,10 +89,14 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
         value(callback.hook_trace).must_equal(
           [visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm),
+
            visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm.child),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm.child),
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm.child),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm.child),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm.child),
+
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm),
            visit(ViewModel::Callbacks::Hook::OnChange,          vm),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm)])
@@ -103,12 +111,16 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
         value(callback.hook_trace).must_equal(
           [visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm),
-           visit(ViewModel::Callbacks::Hook::OnChange,          vm),
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm),
+
            visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm_child),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm_child),
            visit(ViewModel::Callbacks::Hook::OnChange,          vm_child),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm_child),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm_child),
+
+           visit(ViewModel::Callbacks::Hook::OnChange,          vm),
+
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm)])
       end
@@ -122,17 +134,24 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
         value(callback.hook_trace).must_equal(
           [visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm),
+
            visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm.child),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm.child),
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm.child),
            visit(ViewModel::Callbacks::Hook::OnChange,          vm.child),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm.child),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm.child),
-           visit(ViewModel::Callbacks::Hook::OnChange,          vm),
+
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm),
+
            visit(ViewModel::Callbacks::Hook::BeforeVisit,       old_child),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, old_child),
            visit(ViewModel::Callbacks::Hook::OnChange,          old_child),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  old_child),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        old_child),
+
+           visit(ViewModel::Callbacks::Hook::OnChange,          vm),
+
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm)])
       end
@@ -148,15 +167,21 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
         value(callback.hook_trace).must_equal(
           [visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm),
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm),
            visit(ViewModel::Callbacks::Hook::OnChange,          vm),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm),
+
            visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm2),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm2),
+
            visit(ViewModel::Callbacks::Hook::BeforeVisit,       child),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, child),
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    child),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  child),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        child),
+
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm2),
            visit(ViewModel::Callbacks::Hook::OnChange,          vm2),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm2),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm2)])
@@ -187,21 +212,29 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
         vm.model.reload
 
         value(callback.hook_trace).must_equal(
-          [visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm),
-           visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm),
-           visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm.child),
-           visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm.child),
-           visit(ViewModel::Callbacks::Hook::OnChange,          vm.child),
-           visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm.child),
-           visit(ViewModel::Callbacks::Hook::AfterVisit,        vm.child),
-           visit(ViewModel::Callbacks::Hook::OnChange,          vm),
-           visit(ViewModel::Callbacks::Hook::BeforeVisit,       old_child),
-           visit(ViewModel::Callbacks::Hook::BeforeDeserialize, old_child),
-           visit(ViewModel::Callbacks::Hook::OnChange,          old_child),
-           visit(ViewModel::Callbacks::Hook::AfterDeserialize,  old_child),
-           visit(ViewModel::Callbacks::Hook::AfterVisit,        old_child),
-           visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm),
-           visit(ViewModel::Callbacks::Hook::AfterVisit,        vm),
+          [
+            visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm),
+            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm),
+
+            visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm.child),
+            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm.child),
+            visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm.child),
+            visit(ViewModel::Callbacks::Hook::OnChange,          vm.child),
+            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm.child),
+            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm.child),
+
+            visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm),
+
+            visit(ViewModel::Callbacks::Hook::BeforeVisit,       old_child),
+            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, old_child),
+            visit(ViewModel::Callbacks::Hook::OnChange,          old_child),
+            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  old_child),
+            visit(ViewModel::Callbacks::Hook::AfterVisit,        old_child),
+
+            visit(ViewModel::Callbacks::Hook::OnChange,          vm),
+
+            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm),
+            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm),
           ])
       end
     end
@@ -227,22 +260,28 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
         value(callback.hook_trace).must_equal(
           [visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm),
-           visit(ViewModel::Callbacks::Hook::OnChange,          vm),
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm),
+
            visit(ViewModel::Callbacks::Hook::BeforeVisit,       new_child),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, new_child),
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    new_child),
            visit(ViewModel::Callbacks::Hook::OnChange,          new_child),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  new_child),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        new_child),
+
            visit(ViewModel::Callbacks::Hook::BeforeVisit,       old_child_1),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, old_child_1),
            visit(ViewModel::Callbacks::Hook::OnChange,          old_child_1),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  old_child_1),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        old_child_1),
+
            visit(ViewModel::Callbacks::Hook::BeforeVisit,       old_child_2),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, old_child_2),
            visit(ViewModel::Callbacks::Hook::OnChange,          old_child_2),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  old_child_2),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        old_child_2),
+
+           visit(ViewModel::Callbacks::Hook::OnChange,          vm),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm)])
       end
@@ -256,12 +295,16 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
         value(callback.hook_trace).must_equal(
           [visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm),
-           visit(ViewModel::Callbacks::Hook::OnChange,          vm),
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm),
+
            visit(ViewModel::Callbacks::Hook::BeforeVisit,       new_child),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, new_child),
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    new_child),
            visit(ViewModel::Callbacks::Hook::OnChange,          new_child),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  new_child),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        new_child),
+
+           visit(ViewModel::Callbacks::Hook::OnChange,          vm),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm)])
       end
@@ -277,12 +320,15 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
         value(callback.hook_trace).must_equal(
           [visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm),
-           visit(ViewModel::Callbacks::Hook::OnChange,          vm),
+           visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm),
+
            visit(ViewModel::Callbacks::Hook::BeforeVisit,       old_child_1),
            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, old_child_1),
            visit(ViewModel::Callbacks::Hook::OnChange,          old_child_1),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  old_child_1),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        old_child_1),
+
+           visit(ViewModel::Callbacks::Hook::OnChange,          vm),
            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm),
            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm)])
       end
@@ -303,17 +349,21 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
           view['next'] = nil
         end
         value(callback.hook_trace).must_equal(
-          [visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm),
-           visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm),
-           visit(ViewModel::Callbacks::Hook::OnChange,          vm),
-           visit(ViewModel::Callbacks::Hook::BeforeVisit,       child),
-           visit(ViewModel::Callbacks::Hook::BeforeDeserialize, child),
-           visit(ViewModel::Callbacks::Hook::OnChange,          child),
-           visit(ViewModel::Callbacks::Hook::AfterDeserialize,  child),
-           visit(ViewModel::Callbacks::Hook::AfterVisit,        child),
-           visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm),
-           visit(ViewModel::Callbacks::Hook::AfterVisit,        vm),
-])
+          [
+            visit(ViewModel::Callbacks::Hook::BeforeVisit,       vm),
+            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, vm),
+            visit(ViewModel::Callbacks::Hook::BeforeValidate,    vm),
+
+            visit(ViewModel::Callbacks::Hook::BeforeVisit,       child),
+            visit(ViewModel::Callbacks::Hook::BeforeDeserialize, child),
+            visit(ViewModel::Callbacks::Hook::OnChange,          child),
+            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  child),
+            visit(ViewModel::Callbacks::Hook::AfterVisit,        child),
+
+            visit(ViewModel::Callbacks::Hook::OnChange,          vm),
+            visit(ViewModel::Callbacks::Hook::AfterDeserialize,  vm),
+            visit(ViewModel::Callbacks::Hook::AfterVisit,        vm),
+          ])
         ## At present, children aren't deeplyvisited on delete.
         # visit(ViewModel::Callbacks::Hook::BeforeVisit,       grandchild),
         # visit(ViewModel::Callbacks::Hook::BeforeDeserialize, grandchild),


### PR DESCRIPTION
Adds recursive tracking of changes to owned tree children during deserialization, to facilitate hooks that clear caches only on change.

Breaking changes:
* Use internal tracking for attributes and newness instead of delegating to model: clients need to call `x_changed!` in custom deserialize, and `model_is_new!` in custom resolve. This means that VM::AR attribute changes will now correctly correspond to viewmodel attributes instead of peeking through to the model.

* Fully visit and save node and all children before calling on_change hook: this means that hooks that inspect the model's changes will need to inspect `previous_changes`

* `before_save` hook is removed, replaced with `before_validate`. `before_validate` is also called from VM::Record.
