### PR TITLE
Parse PostgreSQL unique constraint violation messages

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,3 +1,3 @@
 module IknowViewModels
-  VERSION = "2.8.0"
+  VERSION = "2.8.1"
 end

--- a/lib/view_model/active_record/update_context.rb
+++ b/lib/view_model/active_record/update_context.rb
@@ -246,7 +246,7 @@ class ViewModel::ActiveRecord
         model_class.connection.execute("SET CONSTRAINTS ALL IMMEDIATE")
       end
     rescue ::ActiveRecord::StatementInvalid => ex
-      raise ViewModel::DeserializationError::DatabaseConstraint.new(ex.message)
+      raise ViewModel::DeserializationError::DatabaseConstraint.from_exception(ex)
     end
   end
 end

--- a/lib/view_model/active_record/update_operation.rb
+++ b/lib/view_model/active_record/update_operation.rb
@@ -205,7 +205,7 @@ class ViewModel::ActiveRecord
       @run_state = RunState::Run
       viewmodel
     rescue ::ActiveRecord::StatementInvalid, ::ActiveRecord::InvalidForeignKey, ::ActiveRecord::RecordNotSaved => ex
-      raise ViewModel::DeserializationError::DatabaseConstraint.new(ex.message, blame_reference)
+      raise ViewModel::DeserializationError::DatabaseConstraint.from_exception(ex, blame_reference)
     end
 
     # Recursively builds UpdateOperations for the associations in our UpdateData

--- a/test/unit/view_model/deserialization_error/unique_violation_test.rb
+++ b/test/unit/view_model/deserialization_error/unique_violation_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'minitest/unit'
+require 'rspec/expectations/minitest_integration'
+
+require 'view_model'
+require 'view_model/deserialization_error'
+
+class ViewModel::DeserializationError::UniqueViolationTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  # Test error parser
+  describe 'message parser' do
+    let(:parse) { ViewModel::DeserializationError::UniqueViolation.parse_message_detail(detail_message) }
+
+    describe 'with a bad message prefix' do
+      let(:detail_message) { 'Unexpected (x)=(y) already exists.' }
+
+      it 'refuses to parse' do
+        expect(parse).to be_nil
+      end
+    end
+
+    describe 'with a bad message suffix' do
+      let(:detail_message) { 'Key (x)=(y) is already present.' }
+
+      it 'refuses to parse' do
+        expect(parse).to be_nil
+      end
+    end
+
+    describe 'with a single key and value' do
+      let(:detail_message) { 'Key (x)=(a) already exists.' }
+
+      it 'parses the key and value' do
+        expect(parse).to eq([['x'], 'a'])
+      end
+    end
+
+    describe 'with multiple keys and values' do
+      let(:detail_message) { 'Key (x, y)=(a, b) already exists.' }
+
+      it 'parses the keys and value' do
+        expect(parse).to eq([['x', 'y'], 'a, b'])
+      end
+    end
+
+    describe 'with quoted keys and values' do
+      let(:detail_message) { 'Key ("x, y", z)=(a, b, c) already exists.' }
+
+      it 'parses the keys and value' do
+        expect(parse).to eq([['x, y', 'z'], 'a, b, c'])
+      end
+    end
+
+    describe 'with nested quoted keys and values' do
+      let(:detail_message) { 'Key ("""x"", ""y""", z)=(a, b, c) already exists.' }
+
+      it 'parses the keys and value' do
+        expect(parse).to eq([['"x", "y"', 'z'], 'a, b, c'])
+      end
+    end
+
+    describe 'with unescaped values' do
+      let(:detail_message) { 'Key (a, b)=(a, b)=(c, d) already exists.' }
+
+      it 'parses the keys and value' do
+        expect(parse).to eq([['a', 'b'], 'a, b)=(c, d'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Make a best effort to extract the constraint name and the violated column and include in metadata