### PR TITLE
Allow ViewModel controllers to also hook view rendering on deserialize

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,3 +1,3 @@
 module IknowViewModels
-  VERSION = "2.8.2"
+  VERSION = "2.8.3"
 end

--- a/lib/view_model/active_record/controller.rb
+++ b/lib/view_model/active_record/controller.rb
@@ -48,6 +48,8 @@ module ViewModel::ActiveRecord::Controller
 
       serialize_context.add_includes(deserialize_context.updated_associations)
 
+      view = yield(view) if block_given?
+
       ViewModel.preload_for_serialization(view, serialize_context: serialize_context)
       prerender_viewmodel(view, serialize_context: serialize_context)
     end


### PR DESCRIPTION
If views require crutches to render, allows those crutches to be provided in the
case of returning newly deserialized views.