### PR TITLE
Allow deserialization of empty new models

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '2.8.7'
+  VERSION = '2.8.8'
 end

--- a/lib/view_model/active_record/update_operation.rb
+++ b/lib/view_model/active_record/update_operation.rb
@@ -127,7 +127,7 @@ class ViewModel::ActiveRecord
 
           # Save if the model has been altered. Covers not only models with
           # view changes but also lock version assertions.
-          if viewmodel.model.changed?
+          if viewmodel.model.changed? || viewmodel.model.new_record?
             debug "-> #{debug_name}: Saving"
             begin
               model.save!

--- a/test/unit/view_model/active_record_test.rb
+++ b/test/unit/view_model/active_record_test.rb
@@ -92,6 +92,12 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
     assert_equal("p", p.name)
   end
 
+  def test_create_from_empty_view
+    view = TrivialView.deserialize_from_view({ '_type' => 'Trivial' })
+    model = view.model
+    assert(!model.new_record?)
+  end
+
   def test_create_from_view_with_explicit_id
     view = {
       "_type" => "Parent",
@@ -160,10 +166,10 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
   def test_editability_checks_create_on_empty_record
     context = ViewModelBase.new_deserialize_context
-    TrivialView.deserialize_from_view({'_type' => 'Trivial' },
-                                      deserialize_context: context)
+    view = TrivialView.deserialize_from_view({'_type' => 'Trivial' },
+                                             deserialize_context: context)
 
-    ref = ViewModel::Reference.new(TrivialView, nil)
+    ref = view.to_reference
     assert_equal([ref], context.valid_edit_refs)
 
     changes = context.valid_edit_changes(ref)


### PR DESCRIPTION
`changed?` is false on a `new` ActiveRecord model despite that it hasn't been persisted. Check for `new_record?` explicitly in UpdateOperation.