### PR TITLE
Update transaction callback record hooks for Rails 6 rc2

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end

--- a/lib/view_model/after_transaction_runner.rb
+++ b/lib/view_model/after_transaction_runner.rb
@@ -4,7 +4,7 @@
 # `add_to_transaction`, the abstract method `after_transaction` will be invoked
 # by AR's callbacks.
 module ViewModel::AfterTransactionRunner
-  def committed!; end
+  def committed!(*); end
 
   def before_committed!
     after_transaction
@@ -20,6 +20,10 @@ module ViewModel::AfterTransactionRunner
     else
       after_transaction
     end
+  end
+
+  def trigger_transactional_callbacks?
+    true
   end
 
   # Override to tie to a specific connection.


### PR DESCRIPTION
`trigger_transactional_callbacks?` was moved to the external interface in https://github.com/rails/rails/commit/718a32ca745672a977a0d4ae401f61f439767405