### PR TITLE
Expose a broader API for the AfterTransactionRunner

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.0.3'
+  VERSION = '3.1.0'
 end

--- a/lib/view_model/active_record/cache/cacheable_view.rb
+++ b/lib/view_model/active_record/cache/cacheable_view.rb
@@ -12,6 +12,12 @@ module ViewModel::ActiveRecord::Cache::CacheableView
   CacheClearer = Struct.new(:cache, :id) do
     include ViewModel::AfterTransactionRunner
 
+    # It's important that we clear the cache before committing, because we rely
+    # on database locking to prevent cache race conditions. We require
+    # reading/refreshing the cache to obtain a FOR SHARE lock, which means that
+    # a reader must wait for a concurrent writer to commit before continuing to
+    # the cache. If the writer cleared the cache after commit, the reader could
+    # obtain old data before the clear, and then save the old data after it.
     def before_commit
       cache.delete(id)
     end

--- a/lib/view_model/active_record/cache/cacheable_view.rb
+++ b/lib/view_model/active_record/cache/cacheable_view.rb
@@ -12,7 +12,11 @@ module ViewModel::ActiveRecord::Cache::CacheableView
   CacheClearer = Struct.new(:cache, :id) do
     include ViewModel::AfterTransactionRunner
 
-    def after_transaction
+    def before_commit
+      cache.delete(id)
+    end
+
+    def after_rollback
       cache.delete(id)
     end
 

--- a/lib/view_model/after_transaction_runner.rb
+++ b/lib/view_model/after_transaction_runner.rb
@@ -4,15 +4,30 @@
 # `add_to_transaction`, the abstract method `after_transaction` will be invoked
 # by AR's callbacks.
 module ViewModel::AfterTransactionRunner
-  def committed!(*); end
+  # Rails' internal API
+  def committed!(*)
+    after_commit
+  end
 
   def before_committed!
-    after_transaction
+    before_commit
   end
 
   def rolledback!(*)
-    after_transaction
+    after_rollback
   end
+
+  def trigger_transactional_callbacks?
+    true
+  end
+
+  # Our simplified API
+
+  def before_commit; end
+
+  def after_commit; end
+
+  def after_rollback; end
 
   def add_to_transaction
     if connection.transaction_open?
@@ -22,9 +37,6 @@ module ViewModel::AfterTransactionRunner
     end
   end
 
-  def trigger_transactional_callbacks?
-    true
-  end
 
   # Override to tie to a specific connection.
   def connection


### PR DESCRIPTION
We want finer control over when we run after-transaction hooks