### PR TITLE
Cloner: don't overwrite ignored associations

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end

--- a/lib/view_model/active_record/cloner.rb
+++ b/lib/view_model/active_record/cloner.rb
@@ -33,12 +33,13 @@ class ViewModel::ActiveRecord::Cloner
 
     # visit the underlying viewmodel for each association, ignoring any
     # customization
+    ignored_associations = @ignored_associations
     node.class._members.each do |name, association_data|
       next unless association_data.is_a?(ViewModel::ActiveRecord::AssociationData)
 
       reflection = association_data.direct_reflection
 
-      if association_ignored?(name)
+      if ignored_associations.include?(name)
         new_associated = nil
       else
         # Load the record associated with the old model
@@ -105,9 +106,5 @@ class ViewModel::ActiveRecord::Cloner
 
   def ignored?
     @ignored
-  end
-
-  def association_ignored?(name)
-    @ignored_associations.include?(name.to_s)
   end
 end

--- a/shell.nix
+++ b/shell.nix
@@ -6,15 +6,5 @@ with import <nixpkgs> {};
 
   gemConfig = (defaultGemConfig.override { postgresql = postgresql_11; });
 
-  ruby = ruby_2_6.overrideAttrs (attrs: {
-    patches = (attrs.patches or []) ++ [
-      # RubyGems has a regression where you can no longer build certain gems
-      # outside their directory. Until this is merged, patch from the pull
-      # request.
-      (fetchpatch {
-        url = https://patch-diff.githubusercontent.com/raw/rubygems/rubygems/pull/2596.patch;
-        sha256 = "0m1s5brd30bqcr8v99sczihm83g270philx83kkw5bpix462fdm3";
-      })
-    ];
-  });
+  ruby = ruby_2_6;
 }).env


### PR DESCRIPTION
When cloning a node with multiple child associations, ignored_associations would
be cleared while visiting the first child association. Save the calculated value
before descending.

