### PR TITLE
Run in-viewmodel callbacks before context callbacks instead of after

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.1.5'
+  VERSION = '3.1.6'
 end

--- a/lib/view_model/traversal_context.rb
+++ b/lib/view_model/traversal_context.rb
@@ -93,12 +93,14 @@ class ViewModel::TraversalContext
   end
 
   def run_callback(hook, view, **args)
-    callbacks.each do |callback|
-      callback.run_callback(hook, view, self, **args)
-    end
-
+    # Run in-viewmodel callback hooks before context hooks, as they are
+    # permitted to alter the model.
     if view.respond_to?(hook.dsl_viewmodel_callback_method)
       view.public_send(hook.dsl_viewmodel_callback_method, hook.context_name => self, **args)
+    end
+
+    callbacks.each do |callback|
+      callback.run_callback(hook, view, self, **args)
     end
   end
 


### PR DESCRIPTION
In-viewmodel callbacks are permitted to alter the model, and so must be run before other non-`updates_view` callbacks, especially access control. Fixes #137.