### PR TITLE
Add ViewModel migrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  TargetRubyVersion: 2.7
+
+inherit_gem:
+  rubocop-iknow: rubocop.yml

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in cerego_view_models.gemspec
 gemspec
 
+# Add our linter rules as a development dependency
+gem 'rubocop'
+gem 'rubocop-iknow'
+
 # Test metadata collection for circleci
 gem 'minitest-ci'
 

--- a/iknow_view_models.gemspec
+++ b/iknow_view_models.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "lazily"
   spec.add_dependency "renum"
   spec.add_dependency "oj"
+  spec.add_dependency "rgl"
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bundler"

--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.1.8'
+  VERSION = '3.2.0'
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -11,8 +11,9 @@ class ViewModel
   TYPE_ATTRIBUTE      = "_type"
   VERSION_ATTRIBUTE   = "_version"
   NEW_ATTRIBUTE       = "_new"
+  MIGRATED_ATTRIBUTE  = "_migrated"
 
-  Metadata = Struct.new(:id, :view_name, :schema_version, :new) do
+  Metadata = Struct.new(:id, :view_name, :schema_version, :new, :migrated) do
     alias :new? :new
   end
 
@@ -99,8 +100,9 @@ class ViewModel
       type_name      = hash.delete(ViewModel::TYPE_ATTRIBUTE)
       schema_version = hash.delete(ViewModel::VERSION_ATTRIBUTE)
       new            = hash.delete(ViewModel::NEW_ATTRIBUTE) { false }
+      migrated       = hash.delete(ViewModel::MIGRATED_ATTRIBUTE) { false }
 
-      Metadata.new(id, type_name, schema_version, new)
+      Metadata.new(id, type_name, schema_version, new, migrated)
     end
 
     def extract_reference_only_metadata(hash)
@@ -108,7 +110,7 @@ class ViewModel
       id             = hash.delete(ViewModel::ID_ATTRIBUTE)
       type_name      = hash.delete(ViewModel::TYPE_ATTRIBUTE)
 
-      Metadata.new(id, type_name, nil, false)
+      Metadata.new(id, type_name, nil, false, false)
     end
 
     def extract_reference_metadata(hash)
@@ -232,6 +234,11 @@ class ViewModel
 
     def accepts_schema_version?(schema_version)
       schema_version == self.schema_version
+    end
+
+    def schema_hash(schema_versions)
+      version_string = schema_versions.to_a.sort.join(',')
+      Base64.urlsafe_encode64(Digest::MD5.digest(version_string))
     end
 
     def preload_for_serialization(viewmodels, serialize_context: new_serialize_context, include_referenced: true, lock: nil)

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -11,6 +11,10 @@ class ViewModel
   TYPE_ATTRIBUTE      = "_type"
   VERSION_ATTRIBUTE   = "_version"
   NEW_ATTRIBUTE       = "_new"
+
+  # Migrations leave a metadata attribute _migrated on any views that they
+  # alter. This attribute is accessible as metadata when deserializing migrated
+  # input, and is included in the output serialization sent to clients.
   MIGRATED_ATTRIBUTE  = "_migrated"
 
   Metadata = Struct.new(:id, :view_name, :schema_version, :new, :migrated) do

--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -245,7 +245,7 @@ class ViewModel::ActiveRecord < ViewModel::Record
         begin
           dependent_viewmodels(include_referenced: include_referenced).each_with_object({}) do |view, h|
             h[view.view_name] = view.schema_version
-          end
+          end.freeze
         end
     end
 

--- a/lib/view_model/active_record/cache.rb
+++ b/lib/view_model/active_record/cache.rb
@@ -5,6 +5,7 @@ require 'iknow_cache'
 # Cache for ViewModels that wrap ActiveRecord models.
 class ViewModel::ActiveRecord::Cache
   require 'view_model/active_record/cache/cacheable_view'
+  require 'view_model/migrator'
 
   class UncacheableViewModelError < RuntimeError; end
 
@@ -13,13 +14,20 @@ class ViewModel::ActiveRecord::Cache
   # If cache_group: is specified, it must be a group of a single key: `:id`
   def initialize(viewmodel_class, cache_group: nil)
     @viewmodel_class = viewmodel_class
-    @cache_group = cache_group || create_default_cache_group # requires @viewmodel_class
+
+    @cache_group = cache_group || create_default_cache_group
+    @migrated_cache_group = @cache_group.register_child_group(:migrated, :version)
+
+    # /viewname/:id/viewname-currentversion
     @cache = @cache_group.register_cache(cache_name)
+
+    # /viewname/:id/migrated/:oldversion/viewname-currentversion
+    @migrated_cache = @migrated_cache_group.register_cache(cache_name)
   end
 
   def delete(*ids)
     ids.each do |id|
-      @cache_group.delete_all(key_for(id))
+      @cache_group.delete_all(@cache.key.new(id))
     end
   end
 
@@ -27,14 +35,14 @@ class ViewModel::ActiveRecord::Cache
     @cache_group.invalidate_cache_group
   end
 
-  def fetch_by_viewmodel(viewmodels, locked: false, serialize_context: @viewmodel_class.new_serialize_context)
+  def fetch_by_viewmodel(viewmodels, migration_versions: {}, locked: false, serialize_context: @viewmodel_class.new_serialize_context)
     ids = viewmodels.map(&:id)
-    fetch(ids, initial_viewmodels: viewmodels, locked: false, serialize_context: serialize_context)
+    fetch(ids, initial_viewmodels: viewmodels, migration_versions: migration_versions, locked: locked, serialize_context: serialize_context)
   end
 
-  def fetch(ids, initial_viewmodels: nil, locked: false, serialize_context: @viewmodel_class.new_serialize_context)
+  def fetch(ids, initial_viewmodels: nil, migration_versions: {}, locked: false, serialize_context: @viewmodel_class.new_serialize_context)
     data_serializations = Array.new(ids.size)
-    worker = CacheWorker.new(serialize_context: serialize_context)
+    worker = CacheWorker.new(migration_versions: migration_versions, serialize_context: serialize_context)
 
     # If initial root viewmodels were provided, visit them to ensure that they
     # are visible. Other than this, no traversal callbacks are performed, as a
@@ -98,12 +106,14 @@ class ViewModel::ActiveRecord::Cache
     SENTINEL = Object.new
     WorklistEntry = Struct.new(:ref_name, :viewmodel)
 
-    attr_reader :serialize_context, :resolved_references
+    attr_reader :migration_versions, :serialize_context, :resolved_references
 
-    def initialize(serialize_context:)
-      @worklist            = {}
-      @resolved_references = {}
-      @serialize_context   = serialize_context
+    def initialize(migration_versions:, serialize_context:)
+      @worklist                = {}
+      @resolved_references     = {}
+      @migration_versions      = migration_versions
+      @migrated_cache_versions = {}
+      @serialize_context       = serialize_context
     end
 
     def resolve_references!
@@ -141,11 +151,15 @@ class ViewModel::ActiveRecord::Cache
       end
     end
 
+    def migrated_cache_version(viewmodel_cache)
+      @migrated_cache_versions[viewmodel_cache] ||= viewmodel_cache.migrated_cache_version(migration_versions)
+    end
+
     # Loads the specified entities from the cache and returns a hash of
     # {id=>serialized_view}. Any references encountered are added to the
     # worklist.
     def load_from_cache(viewmodel_cache, ids)
-      cached_serializations = viewmodel_cache.load(ids, serialize_context: serialize_context)
+      cached_serializations = viewmodel_cache.load(ids, migrated_cache_version(viewmodel_cache), serialize_context: serialize_context)
 
       cached_serializations.each_with_object({}) do |(id, cached_serialization), result|
         add_refs_to_worklist(cached_serialization[:ref_cache])
@@ -159,17 +173,54 @@ class ViewModel::ActiveRecord::Cache
     # added to the worklist.
     def serialize_and_cache(viewmodels)
       viewmodels.each_with_object({}) do |viewmodel, result|
-        data_serialization = Jbuilder.encode do |json|
+        builder = Jbuilder.new do |json|
           ViewModel.serialize(viewmodel, json, serialize_context: serialize_context)
         end
 
         referenced_viewmodels = serialize_context.extract_referenced_views!
+
+        if migration_versions.present?
+          migrator = ViewModel::DownMigrator.new(migration_versions)
+
+          # This migration isn't given the chance to inspect/alter the contents
+          # of referenced views, only their presence: it's strictly less
+          # powerful than migrations on a fully serialized tree, as the only
+          # possible action on a referenced child is to delete it. The effect of
+          # this is that for sufficiently complex migrations where a parent view
+          # must introduce children or alter the contents of its referenced
+          # children, we may have to avoid caching while the migration is in
+          # use.
+          dummy_references = referenced_viewmodels.transform_values do |ref_vm|
+            {
+              ViewModel::TYPE_ATTRIBUTE    => ref_vm.class.view_name,
+              ViewModel::VERSION_ATTRIBUTE => ref_vm.class.schema_version,
+              ViewModel::ID_ATTRIBUTE      => ref_vm.id,
+            }.freeze
+          end
+
+          migrator.migrate!(builder.attributes!, references: dummy_references)
+
+          # Removed dummy references can be removed from referenced_viewmodels.
+          referenced_viewmodels.keep_if { |k, _| dummy_references.has_key?(k) }
+
+          # Introduced dummy references cannot be handled.
+          if dummy_references.keys != referenced_viewmodels.keys
+            version = migration_versions[viewmodel.class]
+            raise ViewModel::Error.new(
+                    status: 500,
+                    detail: "Down-migration for cacheable view #{viewmodel.class} to v#{version} must not introduce new shared references")
+          end
+        end
+
+        data_serialization = builder.target!
+
         add_viewmodels_to_worklist(referenced_viewmodels)
 
         if viewmodel.class < CacheableView
           cacheable_references = referenced_viewmodels.transform_values { |vm| cacheable_reference(vm) }
-          viewmodel.class.viewmodel_cache.store(viewmodel.id, data_serialization, cacheable_references,
-                                                serialize_context: serialize_context)
+          target_cache = viewmodel.class.viewmodel_cache
+          target_cache.store(viewmodel.id, migrated_cache_version(target_cache), data_serialization, cacheable_references,
+                             serialize_context: serialize_context)
         end
 
         result[viewmodel.id] = data_serialization
@@ -225,8 +276,20 @@ class ViewModel::ActiveRecord::Cache
     end
   end
 
-  def key_for(id)
-    cache.key.new(id)
+  def cache_for(migration_version)
+    if migration_version
+      @migrated_cache
+    else
+      @cache
+    end
+  end
+
+  def key_for(id, migration_version)
+    if migration_version
+      @migrated_cache.key.new(id, migration_version)
+    else
+      @cache.key.new(id)
+    end
   end
 
   def id_for(key)
@@ -234,32 +297,47 @@ class ViewModel::ActiveRecord::Cache
   end
 
   # Save the provided serialization and reference data in the cache
-  def store(id, data_serialization, ref_cache, serialize_context:)
-    cache.write(key_for(id), { data: data_serialization, ref_cache: ref_cache })
+  def store(id, migration_version, data_serialization, ref_cache, serialize_context:)
+    key = key_for(id, migration_version)
+    cache_for(migration_version).write(key, { data: data_serialization, ref_cache: ref_cache })
   end
 
-  def load(ids, serialize_context:)
-    keys = ids.map { |id| key_for(id) }
-    results = cache.read_multi(keys)
+  def load(ids, migration_version, serialize_context:)
+    keys = ids.map { |id| key_for(id, migration_version) }
+    results = cache_for(migration_version).read_multi(keys)
     results.transform_keys! { |key| id_for(key) }
   end
 
-  private
+  def cache_version
+    @cache_version ||=
+      begin
+        versions = @viewmodel_class.deep_schema_version(include_referenced: false)
+        ViewModel.schema_hash(versions)
+      end
+  end
 
-  attr_reader :cache
+  def migrated_cache_version(migration_versions)
+    versions = ViewModel::Migrator.migrated_deep_schema_version(viewmodel_class, migration_versions, include_referenced: false)
+    version_hash = ViewModel.schema_hash(versions)
+
+    if version_hash == cache_version
+      # no migrations affect this view
+      nil
+    else
+      version_hash
+    end
+  end
+
+  private
 
   def create_default_cache_group
     IknowCache.register_group(@viewmodel_class.name, :id)
   end
 
-  # Statically version the terminal cache based on the deep schema versions of
-  # the constituent viewmodels, so that viewmodel changes force invalidation.
+  # Statically version the cache name based on the (current) deep schema
+  # versions of the constituent viewmodels, so that viewmodel changes force
+  # invalidation.
   def cache_name
-    "#{@viewmodel_class.name}_#{cache_version}"
-  end
-
-  def cache_version
-    version_string = @viewmodel_class.deep_schema_version(include_referenced: false).to_a.sort.join(',')
-    Base64.urlsafe_encode64(Digest::MD5.digest(version_string))
+    "vmcache_#{cache_version}"
   end
 end

--- a/lib/view_model/active_record/cache/cacheable_view.rb
+++ b/lib/view_model/active_record/cache/cacheable_view.rb
@@ -40,10 +40,10 @@ module ViewModel::ActiveRecord::Cache::CacheableView
       @viewmodel_cache
     end
 
-    def serialize_from_cache(views, serialize_context:)
+    def serialize_from_cache(views, migration_versions: {}, locked: false, serialize_context:)
       plural = views.is_a?(Array)
       views = Array.wrap(views)
-      json_views, json_refs = viewmodel_cache.fetch_by_viewmodel(views, serialize_context: serialize_context)
+      json_views, json_refs = viewmodel_cache.fetch_by_viewmodel(views, locked: locked, migration_versions: migration_versions, serialize_context: serialize_context)
       json_views = json_views.first unless plural
       return json_views, json_refs
     end

--- a/lib/view_model/migratable_view.rb
+++ b/lib/view_model/migratable_view.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'view_model/migration'
+require 'view_model/migrator'
+
+require 'rgl/adjacency'
+require 'rgl/dijkstra'
+
+module ViewModel::MigratableView
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def initialize_as_migratable_view
+      @migrations_lock   = Monitor.new
+      @migration_classes = {}
+      @migration_paths   = {}
+      @realized_migration_paths = true
+    end
+
+    def migration_path(from:, to:)
+      @migrations_lock.synchronize do
+        realize_paths! unless @realized_migration_paths
+
+        migrations = @migration_paths.fetch([from, to]) do
+          raise ViewModel::Migration::NoPathError.new(self, from, to)
+        end
+
+        migrations
+      end
+    end
+
+    private
+
+    # Define a migration on this viewmodel
+    def migrates(from:, to:, &block)
+      @migrations_lock.synchronize do
+        builder = ViewModel::Migration::Builder.new
+        builder.instance_exec(&block)
+        @migration_classes[[from, to]] = builder.build!
+        @realized_migration_paths = false
+      end
+    end
+
+    # Internal: find and record possible paths to the current schema version.
+    def realize_paths!
+      @migration_paths.clear
+
+      graph = RGL::DirectedAdjacencyGraph.new
+
+      # Add edges backwards, as we care about paths from the latest version
+      @migration_classes.each_key do |from, to|
+        graph.add_edge(to, from)
+      end
+
+      paths = graph.dijkstra_shortest_paths(Hash.new { 1 }, self.schema_version)
+
+      paths.each do |target_version, path|
+        next if path.length == 1
+
+        # Store the path forwards rather than backwards
+        path_migration_classes = path.reverse.each_cons(2).map do |from, to|
+          @migration_classes.fetch([from, to])
+        end
+
+        key = [target_version, schema_version]
+
+        @migration_paths[key] = path_migration_classes.map(&:new)
+      end
+
+      @realized_paths = true
+    end
+  end
+end

--- a/lib/view_model/migratable_view.rb
+++ b/lib/view_model/migratable_view.rb
@@ -10,6 +10,11 @@ module ViewModel::MigratableView
   extend ActiveSupport::Concern
 
   class_methods do
+    def inherited(base)
+      super
+      base.initialize_as_migratable_view
+    end
+
     def initialize_as_migratable_view
       @migrations_lock   = Monitor.new
       @migration_classes = {}

--- a/lib/view_model/migration.rb
+++ b/lib/view_model/migration.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class ViewModel::Migration
+  require 'view_model/migration/no_path_error'
+  require 'view_model/migration/one_way_error'
+
+  def up(view, _references)
+    raise ViewModel::Migration::OneWayError.new(view[ViewModel::TYPE_ATTRIBUTE], :up)
+  end
+
+  def down(view, _references)
+    raise ViewModel::Migration::OneWayError.new(view[ViewModel::TYPE_ATTRIBUTE], :down)
+  end
+
+  # Tiny DSL for defining migration classes
+  class Builder
+    def initialize
+      @up_block = nil
+      @down_block = nil
+    end
+
+    def build!
+      migration = Class.new(ViewModel::Migration)
+      migration.define_method(:up, &@up_block) if @up_block
+      migration.define_method(:down, &@down_block) if @down_block
+      migration
+    end
+
+    private
+
+    def up(&block)
+      check_signature!(block)
+      @up_block = block
+    end
+
+    def down(&block)
+      check_signature!(block)
+      @down_block = block
+    end
+
+    def check_signature!(block)
+      unless block.arity == 2
+        raise RuntimeError.new('Illegal signature for migration method, must be (view, references)')
+      end
+    end
+  end
+end

--- a/lib/view_model/migration.rb
+++ b/lib/view_model/migration.rb
@@ -3,6 +3,7 @@
 class ViewModel::Migration
   require 'view_model/migration/no_path_error'
   require 'view_model/migration/one_way_error'
+  require 'view_model/migration/unspecified_version_error'
 
   def up(view, _references)
     raise ViewModel::Migration::OneWayError.new(view[ViewModel::TYPE_ATTRIBUTE], :up)

--- a/lib/view_model/migration/no_path_error.rb
+++ b/lib/view_model/migration/no_path_error.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ViewModel::Migration::NoPathError < ViewModel::AbstractError
+  attr_reader :vm_name, :from, :to
+
+  status 400
+  def initialize(viewmodel, from, to)
+    @vm_name = viewmodel.view_name
+    @from = from
+    @to = to
+  end
+
+  def detail
+    "No migration path for #{vm_name} from #{from} to #{to}"
+  end
+
+  def meta
+    {
+      viewmodel: vm_name,
+      from: from,
+      to: to
+    }
+  end
+end

--- a/lib/view_model/migration/no_path_error.rb
+++ b/lib/view_model/migration/no_path_error.rb
@@ -4,6 +4,7 @@ class ViewModel::Migration::NoPathError < ViewModel::AbstractError
   attr_reader :vm_name, :from, :to
 
   status 400
+
   def initialize(viewmodel, from, to)
     @vm_name = viewmodel.view_name
     @from = from
@@ -18,7 +19,7 @@ class ViewModel::Migration::NoPathError < ViewModel::AbstractError
     {
       viewmodel: vm_name,
       from: from,
-      to: to
+      to: to,
     }
   end
 end

--- a/lib/view_model/migration/one_way_error.rb
+++ b/lib/view_model/migration/one_way_error.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ViewModel::Migration::OneWayError < ViewModel::AbstractError
+  attr_reader :vm_name, :direction
+
+  status 400
+
+  def initialize(vm_name, direction)
+    @vm_name = vm_name
+    @direction = direction
+  end
+
+  def detail
+    "One way migration for #{vm_name} cannot be migrated #{direction}"
+  end
+
+  def meta
+    {
+      viewmodel: vm_name,
+      direction: direction,
+    }
+  end
+end

--- a/lib/view_model/migration/unspecified_version_error.rb
+++ b/lib/view_model/migration/unspecified_version_error.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ViewModel::Migration::UnspecifiedVersionError < ViewModel::AbstractError
+  attr_reader :vm_name, :version
+
+  status 400
+
+  def initialize(vm_name, version)
+    @vm_name = vm_name
+    @version = version
+  end
+
+  def detail
+    "Provided view for #{vm_name} at version #{version} does not match request"
+  end
+
+  def meta
+    {
+      viewmodel: vm_name,
+      version: version,
+    }
+  end
+end

--- a/lib/view_model/migrator.rb
+++ b/lib/view_model/migrator.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+class ViewModel
+  class Migrator
+    class << self
+      def migrated_deep_schema_version(viewmodel_class, required_versions, include_referenced: true)
+        deep_schema_version = viewmodel_class.deep_schema_version(include_referenced: include_referenced)
+
+        if required_versions.present?
+          deep_schema_version = deep_schema_version.dup
+
+          required_versions.each do |required_vm_class, required_version|
+            name = required_vm_class.view_name
+            if deep_schema_version.has_key?(name)
+              deep_schema_version[name] = required_version
+            end
+          end
+        end
+
+        deep_schema_version
+      end
+    end
+
+    def initialize(required_versions)
+      @paths = required_versions.each_with_object({}) do |(viewmodel_class, required_version), h|
+        if required_version != viewmodel_class.schema_version
+          path = viewmodel_class.migration_path(from: required_version, to: viewmodel_class.schema_version)
+          h[viewmodel_class.view_name] = path
+        end
+      end
+
+      @versions = required_versions.each_with_object({}) do |(viewmodel_class, required_version), h|
+        h[viewmodel_class.view_name] = [required_version, viewmodel_class.schema_version]
+      end
+    end
+
+    def migrate!(node, references:)
+      case node
+      when Hash
+        if (type = node[ViewModel::TYPE_ATTRIBUTE])
+          version = node[ViewModel::VERSION_ATTRIBUTE]
+
+          if migrate_viewmodel!(type, version, node, references)
+            node[ViewModel::MIGRATED_ATTRIBUTE] = true
+          end
+        end
+
+        node.each_value do |child|
+          migrate!(child, references: references)
+        end
+      when Array
+        node.each { |child| migrate!(child, references: references) }
+      end
+    end
+
+    private
+
+    def migrate_viewmodel!(_view_name, _version, _view_hash, _references)
+      raise RuntimeError.new('abstract method')
+    end
+  end
+
+  class UpMigrator < Migrator
+    private
+
+    def migrate_viewmodel!(view_name, source_version, view_hash, references)
+      path = @paths[view_name]
+      return false unless path
+
+      # We assume that an unspecified source version is the same as the required
+      # version.
+      required_version, current_version = @versions[view_name]
+      return false unless source_version.nil? || source_version == required_version
+
+      path.each do |migration|
+        migration.up(view_hash, references)
+      end
+
+      view_hash[ViewModel::VERSION_ATTRIBUTE] = current_version
+
+      true
+    end
+  end
+
+  # down migrations find a reverse path from the current schema version to the
+  # specific version requested by the client.
+  class DownMigrator < Migrator
+    private
+
+    def migrate_viewmodel!(view_name, _, view_hash, references)
+      path = @paths[view_name]
+      return false unless path
+
+      required_version, _current_version = @versions[view_name]
+
+      path.reverse_each do |migration|
+        migration.down(view_hash, references)
+      end
+
+      view_hash[ViewModel::VERSION_ATTRIBUTE] = required_version
+
+      true
+    end
+  end
+end

--- a/lib/view_model/migrator.rb
+++ b/lib/view_model/migrator.rb
@@ -70,7 +70,10 @@ class ViewModel
       # We assume that an unspecified source version is the same as the required
       # version.
       required_version, current_version = @versions[view_name]
-      return false unless source_version.nil? || source_version == required_version
+
+      unless source_version.nil? || source_version == required_version
+        raise ViewModel::Migration::UnspecifiedVersionError.new(view_name, source_version)
+      end
 
       path.each do |migration|
         migration.up(view_hash, references)

--- a/lib/view_model/record.rb
+++ b/lib/view_model/record.rb
@@ -10,6 +10,7 @@ class ViewModel::Record < ViewModel
   attr_accessor :model
 
   require 'view_model/record/attribute_data'
+  require 'view_model/migratable_view'
 
   class << self
     attr_reader :_members
@@ -25,6 +26,9 @@ class ViewModel::Record < ViewModel
       @_members       = {}
       @abstract_class = false
       @unregistered   = false
+
+      include ViewModel::MigratableView
+      initialize_as_migratable_view
 
       @generated_accessor_module = Module.new
       include @generated_accessor_module
@@ -207,7 +211,7 @@ class ViewModel::Record < ViewModel
   end
 
   def serialize_view(json, serialize_context: self.class.new_serialize_context)
-    json.set!(ViewModel::ID_ATTRIBUTE, model.id) if model.respond_to?(:id)
+    json.set!(ViewModel::ID_ATTRIBUTE, self.id) if stable_id?
     json.set!(ViewModel::TYPE_ATTRIBUTE, self.view_name)
     json.set!(ViewModel::VERSION_ATTRIBUTE, self.class.schema_version)
 

--- a/lib/view_model/record.rb
+++ b/lib/view_model/record.rb
@@ -12,6 +12,8 @@ class ViewModel::Record < ViewModel
   require 'view_model/record/attribute_data'
   require 'view_model/migratable_view'
 
+  include ViewModel::MigratableView
+
   class << self
     attr_reader :_members
     attr_accessor :abstract_class, :unregistered
@@ -26,9 +28,6 @@ class ViewModel::Record < ViewModel
       @_members       = {}
       @abstract_class = false
       @unregistered   = false
-
-      include ViewModel::MigratableView
-      initialize_as_migratable_view
 
       @generated_accessor_module = Module.new
       include @generated_accessor_module

--- a/lib/view_model/test_helpers/arvm_builder.rb
+++ b/lib/view_model/test_helpers/arvm_builder.rb
@@ -4,7 +4,8 @@ class ViewModel::TestHelpers::ARVMBuilder
   # Building an ARVM requires three blocks, to define schema, model and
   # viewmodel. Support providing these either in an spec argument or as a
   # dsl-style builder.
-  Spec = Struct.new(:schema, :model, :viewmodel) do
+  Spec = Struct.new(:schema, :model, :viewmodel)
+  class Spec
     def initialize(schema:, model:, viewmodel:)
       super(schema, model, viewmodel)
     end

--- a/nix/gem/generate.rb
+++ b/nix/gem/generate.rb
@@ -21,7 +21,7 @@ require 'bundler'
 
 lockfile = Bundler::LockfileParser.new(File.read('Gemfile.lock'))
 gems = lockfile.specs.select { |spec| spec.source.is_a?(Bundler::Source::Rubygems) }
-sources = [URI('https://rubygems.org/')] | gems.map(&:source).flat_map(&:remotes)
+sources = gems.map(&:source).flat_map(&:remotes).uniq
 
 FileUtils.mkdir_p 'nix/gem'
 Dir.chdir 'nix/gem' do

--- a/test/helpers/controller_test_helpers.rb
+++ b/test/helpers/controller_test_helpers.rb
@@ -79,11 +79,25 @@ module ControllerTestModels
       end
       define_viewmodel do
         root!
+        self.schema_version = 2
+
         attributes   :name
         associations :label, :target
         association  :children
         association  :poly, viewmodels: [:PolyOne, :PolyTwo]
         association  :category, external: true
+
+        migrates from: 1, to: 2 do
+          up do |view, _refs|
+            if view.has_key?('old_name')
+              view['name'] = view.delete('old_name')
+            end
+          end
+
+          down do |view, refs|
+            view['old_name'] = view.delete('name')
+          end
+        end
       end
     end
 

--- a/test/unit/view_model/active_record/migration_test.rb
+++ b/test/unit/view_model/active_record/migration_test.rb
@@ -1,0 +1,150 @@
+require_relative "../../../helpers/arvm_test_utilities.rb"
+require_relative "../../../helpers/arvm_test_models.rb"
+require_relative "../../../helpers/viewmodel_spec_helpers.rb"
+
+require "minitest/autorun"
+
+require "view_model/active_record"
+
+class ViewModel::ActiveRecord::Migration < ActiveSupport::TestCase
+  include ARVMTestUtilities
+  extend Minitest::Spec::DSL
+
+  include ViewModelSpecHelpers::ParentAndBelongsToChildWithMigration
+
+  def new_model
+    model_class.new(name: 'm1', child: child_model_class.new(name: 'c1'))
+  end
+
+  let(:viewmodel) { create_viewmodel! }
+
+  let(:current_serialization) { ViewModel.serialize_to_hash(viewmodel) }
+
+  let(:v2_serialization) do
+    {
+      ViewModel::TYPE_ATTRIBUTE => viewmodel_class.view_name,
+      ViewModel::VERSION_ATTRIBUTE => 2,
+      ViewModel::ID_ATTRIBUTE => viewmodel.id,
+      'name' => viewmodel.name,
+      'old_field' => 1,
+      'child' => {
+        ViewModel::TYPE_ATTRIBUTE => child_viewmodel_class.view_name,
+        ViewModel::VERSION_ATTRIBUTE => 2,
+        ViewModel::ID_ATTRIBUTE => viewmodel.child.id,
+        'name' => viewmodel.child.name,
+        'former_field' => 'former_value',
+      }
+    }
+  end
+
+  let(:migration_versions) { { viewmodel_class => 2, child_viewmodel_class => 2 } }
+
+  let(:down_migrator) { ViewModel::DownMigrator.new(migration_versions) }
+  let(:up_migrator) { ViewModel::UpMigrator.new(migration_versions) }
+
+  def migrate!
+    migrator.migrate!(subject, references: {})
+  end
+
+
+  describe 'downwards' do
+    let(:migrator) { down_migrator }
+    let(:subject) { current_serialization.deep_dup }
+
+    let(:expected_result) do
+      v2_serialization.deep_merge(
+        {
+          ViewModel::MIGRATED_ATTRIBUTE => true,
+          'old_field' => -1,
+          'child' => {
+            ViewModel::MIGRATED_ATTRIBUTE => true,
+            'former_field' => 'reconstructed'
+          }
+        }
+      )
+    end
+
+    it 'migrates' do
+      migrate!
+
+      assert_equal(expected_result, subject)
+    end
+
+
+    describe 'to an unreachable version' do
+      let(:migration_versions) { { viewmodel_class => 2, child_viewmodel_class => 1 } }
+
+      it 'raises' do
+        assert_raises(ViewModel::Migration::NoPathError) do
+          migrate!
+        end
+      end
+    end
+  end
+
+  describe 'upwards' do
+    let(:migrator) { up_migrator }
+    let(:subject) { v2_serialization.deep_dup }
+
+    let(:expected_result) do
+      current_serialization.deep_merge(
+        ViewModel::MIGRATED_ATTRIBUTE => true,
+        'new_field' => 3,
+        'child' => {
+          ViewModel::MIGRATED_ATTRIBUTE => true,
+        }
+      )
+    end
+
+    it 'migrates' do
+      migrate!
+
+      assert_equal(expected_result, subject)
+    end
+
+    describe 'with a version not in the specification' do
+      let(:subject) do
+        v2_serialization
+          .except('old_field')
+          .deep_merge(ViewModel::VERSION_ATTRIBUTE => 3, 'mid_field' => 1)
+      end
+
+      it 'leaves it alone' do
+        migrate!
+
+        refute(subject.has_key?([ViewModel::MIGRATED_ATTRIBUTE]))
+        assert_equal(3, subject[ViewModel::VERSION_ATTRIBUTE])
+      end
+    end
+
+    describe 'from an unreachable version' do
+      let(:migration_versions) { { viewmodel_class => 2, child_viewmodel_class => 1 } }
+
+      let(:subject) do
+        v2_serialization.deep_merge(
+          'child' => { ViewModel::VERSION_ATTRIBUTE => 1 }
+        )
+      end
+
+      it 'raises' do
+        assert_raises(ViewModel::Migration::NoPathError) do
+          migrate!
+        end
+      end
+    end
+
+    describe 'in an undefined direction' do
+      let(:migration_versions) { { viewmodel_class => 1, child_viewmodel_class => 2 } }
+
+      let(:subject) do
+        v2_serialization.except('old_field').merge(ViewModel::VERSION_ATTRIBUTE => 1)
+      end
+
+      it 'raises' do
+        assert_raises(ViewModel::Migration::OneWayError) do
+          migrate!
+        end
+      end
+    end
+  end
+end

--- a/test/unit/view_model/active_record/migration_test.rb
+++ b/test/unit/view_model/active_record/migration_test.rb
@@ -102,6 +102,18 @@ class ViewModel::ActiveRecord::Migration < ActiveSupport::TestCase
       assert_equal(expected_result, subject)
     end
 
+    describe 'with version unspecified' do
+      let(:subject) do
+        v2_serialization
+          .except(ViewModel::VERSION_ATTRIBUTE)
+      end
+
+      it 'treats it as the requested version' do
+        migrate!
+        assert_equal(expected_result, subject)
+      end
+    end
+
     describe 'with a version not in the specification' do
       let(:subject) do
         v2_serialization
@@ -109,11 +121,10 @@ class ViewModel::ActiveRecord::Migration < ActiveSupport::TestCase
           .deep_merge(ViewModel::VERSION_ATTRIBUTE => 3, 'mid_field' => 1)
       end
 
-      it 'leaves it alone' do
-        migrate!
-
-        refute(subject.has_key?([ViewModel::MIGRATED_ATTRIBUTE]))
-        assert_equal(3, subject[ViewModel::VERSION_ATTRIBUTE])
+      it 'rejects it' do
+        assert_raises(ViewModel::Migration::UnspecifiedVersionError) do
+          migrate!
+        end
       end
     end
 


### PR DESCRIPTION
`ViewModel::Record`s may now use `migrates` blocks to define a JSON-level transformation of the serialized data to previous `schema_version`s. VM::AR::Controller and VM::Cache are augmented to use these migrations to support requesting and supplying views at specific versions.