### PR TITLE
Drop padding in schema hashes

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.2.5'
+  VERSION = '3.2.6'
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -245,7 +245,7 @@ class ViewModel
 
     def schema_hash(schema_versions)
       version_string = schema_versions.to_a.sort.join(',')
-      Base64.urlsafe_encode64(Digest::MD5.digest(version_string))
+      Base64.urlsafe_encode64(Digest::MD5.digest(version_string), padding: false)
     end
 
     def preload_for_serialization(viewmodels, serialize_context: new_serialize_context, include_referenced: true, lock: nil)


### PR DESCRIPTION
This results in shorter nicer names, but will invalidate existing cached values.