### PR TITLE
Change schema hash function to be more Javascript-friendly

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.2.6'
+  VERSION = '3.2.7'
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -245,7 +245,9 @@ class ViewModel
 
     def schema_hash(schema_versions)
       version_string = schema_versions.to_a.sort.join(',')
-      Base64.urlsafe_encode64(Digest::MD5.digest(version_string), padding: false)
+      # We want a short hash value, as this will be used in cache keys
+      hash = Digest::SHA256.digest(version_string).byteslice(0, 16)
+      Base64.urlsafe_encode64(hash, padding: false)
     end
 
     def preload_for_serialization(viewmodels, serialize_context: new_serialize_context, include_referenced: true, lock: nil)


### PR DESCRIPTION
While maintaining the same length. We now use the first 16 bytes of SHA256
instead of MD5. By changing the hash function, we invalidate currently cached
values.