### PR TITLE
Fix memoization of deep_schema_version

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.2.7'
+  VERSION = '3.2.8'
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -243,6 +243,12 @@ class ViewModel
       schema_version == self.schema_version
     end
 
+    def schema_versions(viewmodels)
+      viewmodels.each_with_object({}) do |view, h|
+        h[view.view_name] = view.schema_version
+      end
+    end
+
     def schema_hash(schema_versions)
       version_string = schema_versions.to_a.sort.join(',')
       # We want a short hash value, as this will be used in cache keys

--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -243,11 +243,10 @@ class ViewModel::ActiveRecord < ViewModel::Record
     end
 
     def deep_schema_version(include_referenced: true, include_external: true)
-      (@deep_schema_version ||= {})[include_referenced] ||=
+      (@deep_schema_version ||= {})[[include_referenced, include_external]] ||=
         begin
-          dependent_viewmodels(include_referenced: include_referenced, include_external: include_external).each_with_object({}) do |view, h|
-            h[view.view_name] = view.schema_version
-          end.freeze
+          vms = dependent_viewmodels(include_referenced: include_referenced, include_external: include_external)
+          ViewModel.schema_versions(vms).freeze
         end
     end
 


### PR DESCRIPTION
The new `include_external` parameter wasn't being included in the memoization key.