### PR TITLE
Break vm schema cycles in eager loading

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.2.12'
+  VERSION = '3.2.13'
 end

--- a/test/unit/view_model/active_record_test.rb
+++ b/test/unit/view_model/active_record_test.rb
@@ -416,6 +416,11 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
       @list = List.new(child: List.new(child: nil))
     end
 
+    def test_list_eager_includes
+      expected_includes = 3.times.inject(nil) { |x| DeepPreloader::Spec.new({ 'child' => x }) }
+      assert_equal(expected_includes, ListView.eager_includes)
+    end
+
     def test_deserialize_context
       view = {
         '_type' => 'List',


### PR DESCRIPTION
Allow two recursions to permit a slightly deeper eager load