### PR TITLE
Allow rendering using cache even when the roots aren't cacheable

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.2.13'
+  VERSION = '3.2.14'
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -173,6 +173,17 @@ class ViewModel
       Jbuilder.new { |json| serialize(viewmodel, json, serialize_context: serialize_context) }.attributes!
     end
 
+    def serialize_from_cache(views, migration_versions: {}, locked: false, serialize_context:)
+      plural = views.is_a?(Array)
+      views = Array.wrap(views)
+
+      json_views, json_refs = ViewModel::ActiveRecord::Cache.render_viewmodels_from_cache(
+                    views, locked: locked, migration_versions: migration_versions, serialize_context: serialize_context)
+
+      json_views = json_views.first unless plural
+      return json_views, json_refs
+    end
+
     def encode_json(value)
       # Jbuilder#encode no longer uses MultiJson, but instead calls `.to_json`. In
       # the context of ActiveSupport, we don't want this, because AS replaces the

--- a/lib/view_model/active_record/cache/cacheable_view.rb
+++ b/lib/view_model/active_record/cache/cacheable_view.rb
@@ -39,14 +39,6 @@ module ViewModel::ActiveRecord::Cache::CacheableView
     def viewmodel_cache
       @viewmodel_cache
     end
-
-    def serialize_from_cache(views, migration_versions: {}, locked: false, serialize_context:)
-      plural = views.is_a?(Array)
-      views = Array.wrap(views)
-      json_views, json_refs = viewmodel_cache.fetch_by_viewmodel(views, locked: locked, migration_versions: migration_versions, serialize_context: serialize_context)
-      json_views = json_views.first unless plural
-      return json_views, json_refs
-    end
   end
 
   # Clear the cache if the view or its nested children were changed during


### PR DESCRIPTION
Light refactor of ViewModel::AR::Cache to move rendering of roots into the CacheWorker, and to change the entrypoint to a class method to allow rendering from non-cacheable roots.