### PR TITLE
Nested controller method locking

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.3.0'
+  VERSION = '3.3.1'
 end

--- a/lib/view_model/active_record/singular_nested_controller.rb
+++ b/lib/view_model/active_record/singular_nested_controller.rb
@@ -20,15 +20,15 @@ module ViewModel::ActiveRecord::SingularNestedController
   extend ActiveSupport::Concern
   include ViewModel::ActiveRecord::NestedControllerBase
 
-  def show_associated(scope: nil, serialize_context: new_serialize_context, deserialize_context: new_deserialize_context, &block)
-    show_association(scope: scope, serialize_context: serialize_context, &block)
+  def show_associated(scope: nil, serialize_context: new_serialize_context, lock_owner: nil, &block)
+    show_association(scope: scope, serialize_context: serialize_context, lock_owner: lock_owner, &block)
   end
 
-  def create_associated(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context, &block)
-    write_association(serialize_context: serialize_context, deserialize_context: deserialize_context, &block)
+  def create_associated(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context, lock_owner: nil, &block)
+    write_association(serialize_context: serialize_context, deserialize_context: deserialize_context, lock_owner: lock_owner, &block)
   end
 
-  def destroy_associated(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context)
-    destroy_association(false, serialize_context: serialize_context, deserialize_context: deserialize_context)
+  def destroy_associated(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context, lock_owner: nil)
+    destroy_association(false, serialize_context: serialize_context, deserialize_context: deserialize_context, lock_owner: lock_owner)
   end
 end

--- a/test/unit/view_model/active_record/has_many_test.rb
+++ b/test/unit/view_model/active_record/has_many_test.rb
@@ -808,6 +808,39 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     assert_match(/Removed entities must have only _type and id fields/, ex.message)
   end
 
+  def test_functional_update_move
+    c1_id, c2_id, c3_id = @model1.children.pluck(:id)
+    c4_id, c5_id = @model2.children.pluck(:id)
+
+    remove_fupdate = build_fupdate do
+      remove([{ '_type' => 'Child', 'id' => c2_id }])
+    end
+
+    append_fupdate = build_fupdate do
+      append([{ '_type' => 'Child', 'id' => c2_id }])
+    end
+
+    move_view = [
+      {
+        '_type' => 'Model',
+        'id'       => @model1.id,
+        'children' => remove_fupdate
+      },
+      {
+        '_type' => 'Model',
+        'id'       => @model2.id,
+        'children' => append_fupdate
+      }
+    ]
+
+    viewmodel_class.deserialize_from_view(move_view)
+    @model1.reload
+    @model2.reload
+
+    assert_equal([c1_id, c3_id], @model1.children.pluck(:id))
+    assert_equal([c4_id, c5_id, c2_id], @model2.children.pluck(:id))
+  end
+
   def test_functional_update_update_success
     c1_id, c2_id, c3_id = @model1.children.pluck(:id)
 


### PR DESCRIPTION
Support locking owner viewmodel in nested controller methods. Before this, there was no way for a controller extending this to add a lock that would be within the transaction before the (de)serialization operation, without also capturing the `render_json_string`.