### PR TITLE
Remove context from eager includes

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.3.1'
+  VERSION = '3.4.0'
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -134,7 +134,7 @@ class ViewModel
     # If this viewmodel represents an AR model, what associations does it make
     # use of? Returns a includes spec appropriate for DeepPreloader, either as
     # AR-style nested hashes or DeepPreloader::Spec.
-    def eager_includes(serialize_context: new_serialize_context, include_referenced: true)
+    def eager_includes(include_referenced: true)
       {}
     end
 
@@ -267,10 +267,10 @@ class ViewModel
       Base64.urlsafe_encode64(hash, padding: false)
     end
 
-    def preload_for_serialization(viewmodels, serialize_context: new_serialize_context, include_referenced: true, lock: nil)
+    def preload_for_serialization(viewmodels, include_referenced: true, lock: nil)
       Array.wrap(viewmodels).group_by(&:class).each do |type, views|
         DeepPreloader.preload(views.map(&:model),
-                              type.eager_includes(serialize_context: serialize_context, include_referenced: include_referenced),
+                              type.eager_includes(include_referenced: include_referenced),
                               lock: lock)
       end
     end
@@ -354,8 +354,8 @@ class ViewModel
     context.for_child(self, association_name: member_name)
   end
 
-  def preload_for_serialization(lock: nil, serialize_context: self.class.new_serialize_context)
-    ViewModel.preload_for_serialization([self], lock: lock, serialize_context: serialize_context)
+  def preload_for_serialization(lock: nil)
+    ViewModel.preload_for_serialization([self], lock: lock)
   end
 
   def ==(other)

--- a/lib/view_model/active_record/association_manipulation.rb
+++ b/lib/view_model/active_record/association_manipulation.rb
@@ -34,10 +34,7 @@ module ViewModel::ActiveRecord::AssociationManipulation
 
     vms = association_scope.map { |model| associated_viewmodel.new(model) }
 
-    if eager_include
-      child_context = self.context_for_child(association_name, context: serialize_context)
-      ViewModel.preload_for_serialization(vms, serialize_context: child_context)
-    end
+    ViewModel.preload_for_serialization(vms) if eager_include
 
     if association_data.collection?
       vms

--- a/lib/view_model/active_record/cache.rb
+++ b/lib/view_model/active_record/cache.rb
@@ -279,15 +279,13 @@ class ViewModel::ActiveRecord::Cache
       if ids.present?
         found = viewmodel_class.find(ids,
                                      eager_include: false,
-                                     lock: 'FOR SHARE',
-                                     serialize_context: serialize_context)
+                                     lock: 'FOR SHARE')
         viewmodels.concat(found)
       end
 
       ViewModel.preload_for_serialization(viewmodels,
                                           include_referenced: false,
-                                          lock: 'FOR SHARE',
-                                          serialize_context: serialize_context)
+                                          lock: 'FOR SHARE')
 
       viewmodels
     end

--- a/lib/view_model/active_record/cache.rb
+++ b/lib/view_model/active_record/cache.rb
@@ -196,7 +196,7 @@ class ViewModel::ActiveRecord::Cache
     # {id=>serialized_view}. Any references encountered are added to the
     # worklist.
     def load_from_cache(viewmodel_cache, ids)
-      cached_serializations = viewmodel_cache.load(ids, migrated_cache_version(viewmodel_cache), serialize_context: serialize_context)
+      cached_serializations = viewmodel_cache.load(ids, migrated_cache_version(viewmodel_cache))
 
       cached_serializations.each_with_object({}) do |(id, cached_serialization), result|
         add_refs_to_worklist(cached_serialization[:ref_cache])
@@ -255,8 +255,7 @@ class ViewModel::ActiveRecord::Cache
         if viewmodel.class < CacheableView
           cacheable_references = referenced_viewmodels.transform_values { |vm| cacheable_reference(vm) }
           target_cache = viewmodel.class.viewmodel_cache
-          target_cache.store(viewmodel.id, migrated_cache_version(target_cache), data_serialization, cacheable_references,
-                             serialize_context: serialize_context)
+          target_cache.store(viewmodel.id, migrated_cache_version(target_cache), data_serialization, cacheable_references)
         end
 
         result[viewmodel.id] = data_serialization
@@ -333,12 +332,12 @@ class ViewModel::ActiveRecord::Cache
   end
 
   # Save the provided serialization and reference data in the cache
-  def store(id, migration_version, data_serialization, ref_cache, serialize_context:)
+  def store(id, migration_version, data_serialization, ref_cache)
     key = key_for(id, migration_version)
     cache_for(migration_version).write(key, { data: data_serialization, ref_cache: ref_cache })
   end
 
-  def load(ids, migration_version, serialize_context:)
+  def load(ids, migration_version)
     keys = ids.map { |id| key_for(id, migration_version) }
     results = cache_for(migration_version).read_multi(keys)
     results.transform_keys! { |key| id_for(key) }

--- a/lib/view_model/active_record/collection_nested_controller.rb
+++ b/lib/view_model/active_record/collection_nested_controller.rb
@@ -50,7 +50,7 @@ module ViewModel::ActiveRecord::CollectionNestedController
         raise ViewModel::DeserializationError::InvalidSyntax.new('Can not provide both `before` and `after` anchors for a collection append')
       end
 
-      owner_view = owner_viewmodel.find(owner_viewmodel_id, eager_include: false, lock: lock_owner, serialize_context: serialize_context)
+      owner_view = owner_viewmodel.find(owner_viewmodel_id, eager_include: false, lock: lock_owner)
 
       assoc_view = owner_view.append_associated(association_name,
                                                 update_hash,
@@ -60,7 +60,7 @@ module ViewModel::ActiveRecord::CollectionNestedController
                                                 deserialize_context: deserialize_context)
       ViewModel::Callbacks.wrap_serialize(owner_view, context: serialize_context) do
         child_context = owner_view.context_for_child(association_name, context: serialize_context)
-        ViewModel.preload_for_serialization(assoc_view, serialize_context: child_context)
+        ViewModel.preload_for_serialization(assoc_view)
         assoc_view = yield(assoc_view) if block_given?
         prerender_viewmodel(assoc_view, serialize_context: child_context)
       end
@@ -71,7 +71,7 @@ module ViewModel::ActiveRecord::CollectionNestedController
 
   def disassociate(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context, lock_owner: nil)
     owner_viewmodel.transaction do
-      owner_view = owner_viewmodel.find(owner_viewmodel_id, eager_include: false, lock: lock_owner, serialize_context: serialize_context)
+      owner_view = owner_viewmodel.find(owner_viewmodel_id, eager_include: false, lock: lock_owner)
       owner_view.delete_associated(association_name, viewmodel_id, type: viewmodel_class, deserialize_context: deserialize_context)
       render_viewmodel(nil)
     end

--- a/lib/view_model/active_record/controller.rb
+++ b/lib/view_model/active_record/controller.rb
@@ -22,7 +22,7 @@ module ViewModel::ActiveRecord::Controller
   def show(scope: nil, viewmodel_class: self.viewmodel_class, serialize_context: new_serialize_context(viewmodel_class: viewmodel_class))
     view = nil
     pre_rendered = viewmodel_class.transaction do
-      view = viewmodel_class.find(viewmodel_id, scope: scope, serialize_context: serialize_context)
+      view = viewmodel_class.find(viewmodel_id, scope: scope)
       view = yield(view) if block_given?
       prerender_viewmodel(view, serialize_context: serialize_context)
     end
@@ -33,7 +33,7 @@ module ViewModel::ActiveRecord::Controller
   def index(scope: nil, viewmodel_class: self.viewmodel_class, serialize_context: new_serialize_context(viewmodel_class: viewmodel_class))
     views = nil
     pre_rendered = viewmodel_class.transaction do
-      views = viewmodel_class.load(scope: scope, serialize_context: serialize_context)
+      views = viewmodel_class.load(scope: scope)
       views = yield(views) if block_given?
       prerender_viewmodel(views, serialize_context: serialize_context)
     end
@@ -47,7 +47,7 @@ module ViewModel::ActiveRecord::Controller
     view = nil
     pre_rendered = viewmodel_class.transaction do
       view = viewmodel_class.deserialize_from_view(update_hash, references: refs, deserialize_context: deserialize_context)
-      ViewModel.preload_for_serialization(view, serialize_context: serialize_context)
+      ViewModel.preload_for_serialization(view)
       view = yield(view) if block_given?
       prerender_viewmodel(view, serialize_context: serialize_context)
     end
@@ -57,7 +57,7 @@ module ViewModel::ActiveRecord::Controller
 
   def destroy(serialize_context: new_serialize_context, deserialize_context: new_deserialize_context)
     viewmodel_class.transaction do
-      view = viewmodel_class.find(viewmodel_id, eager_include: false, serialize_context: serialize_context)
+      view = viewmodel_class.find(viewmodel_id, eager_include: false)
       view.destroy!(deserialize_context: deserialize_context)
     end
     render_viewmodel(nil)

--- a/lib/view_model/active_record/nested_controller_base.rb
+++ b/lib/view_model/active_record/nested_controller_base.rb
@@ -12,10 +12,10 @@ module ViewModel::ActiveRecord::NestedControllerBase
   def show_association(scope: nil, serialize_context: new_serialize_context, lock_owner: nil)
     associated_views = nil
     pre_rendered = owner_viewmodel.transaction do
-      owner_view = owner_viewmodel.find(owner_viewmodel_id, eager_include: false, lock: lock_owner, serialize_context: serialize_context)
+      owner_view = owner_viewmodel.find(owner_viewmodel_id, eager_include: false, lock: lock_owner)
       ViewModel::Callbacks.wrap_serialize(owner_view, context: serialize_context) do
         # Association manipulation methods construct child contexts internally
-        associated_views = owner_view.load_associated(association_name, scope: scope, serialize_context: serialize_context)
+        associated_views = owner_view.load_associated(association_name, scope: scope)
 
         associated_views = yield(associated_views) if block_given?
 
@@ -32,7 +32,7 @@ module ViewModel::ActiveRecord::NestedControllerBase
     pre_rendered = owner_viewmodel.transaction do
       update_hash, refs = parse_viewmodel_updates
 
-      owner_view = owner_viewmodel.find(owner_viewmodel_id, eager_include: false, lock: lock_owner, serialize_context: serialize_context)
+      owner_view = owner_viewmodel.find(owner_viewmodel_id, eager_include: false, lock: lock_owner)
 
       association_view = owner_view.replace_associated(association_name, update_hash,
                                                        references: refs,
@@ -40,7 +40,7 @@ module ViewModel::ActiveRecord::NestedControllerBase
 
       ViewModel::Callbacks.wrap_serialize(owner_view, context: serialize_context) do
         child_context = owner_view.context_for_child(association_name, context: serialize_context)
-        ViewModel.preload_for_serialization(association_view, serialize_context: child_context)
+        ViewModel.preload_for_serialization(association_view)
         association_view = yield(association_view) if block_given?
         prerender_viewmodel(association_view, serialize_context: child_context)
       end
@@ -51,7 +51,7 @@ module ViewModel::ActiveRecord::NestedControllerBase
 
   def destroy_association(collection, serialize_context: new_serialize_context, deserialize_context: new_deserialize_context, lock_owner: nil)
     if lock_owner
-      owner_viewmodel.find(owner_viewmodel_id, eager_include: false, lock: lock_owner, serialize_context: serialize_context)
+      owner_viewmodel.find(owner_viewmodel_id, eager_include: false, lock: lock_owner)
     end
 
     empty_update = collection ? [] : nil

--- a/test/unit/view_model/active_record/has_many_through_poly_test.rb
+++ b/test/unit/view_model/active_record/has_many_through_poly_test.rb
@@ -118,7 +118,7 @@ class ViewModel::ActiveRecord::HasManyThroughPolyTest < ActiveSupport::TestCase
   def test_loading_batching
     context = ParentView.new_serialize_context
     log_queries do
-      parent_views = ParentView.load(serialize_context: context)
+      parent_views = ParentView.load
       serialize(parent_views, serialize_context: context)
     end
 

--- a/test/unit/view_model/active_record/has_many_through_test.rb
+++ b/test/unit/view_model/active_record/has_many_through_test.rb
@@ -112,7 +112,7 @@ class ViewModel::ActiveRecord::HasManyThroughTest < ActiveSupport::TestCase
   def test_loading_batching
     context = ParentView.new_serialize_context
     log_queries do
-      parent_views = ParentView.load(serialize_context: context)
+      parent_views = ParentView.load
       serialize(parent_views, serialize_context: context)
     end
 


### PR DESCRIPTION
Before the prune/include support was dropped, `eager_includes` required a `serialize_context` to calculate pruning. This wasn't removed from the signature at the time pruning was removed, even though it became no longer used. This had consequent effects on the signatures of methods that called eager_includes, such as `ViewModel.preload_for_serialization`, `VM::AR.load`, and `VM::AR.find`.