### PR TITLE
Support STI polymorphism in collection associations

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.4.0'
+  VERSION = '3.4.1'
 end

--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -339,7 +339,7 @@ class ViewModel::ActiveRecord < ViewModel::Record
       # associated here are join-table models; we need to get the far side out
       join_models = associated
 
-      if association_data.direct_viewmodel._list_member?
+      if association_data.ordered?
         attr = association_data.direct_viewmodel._list_attribute_name
         join_models = join_models.sort_by { |j| j[attr] }
       end
@@ -350,11 +350,16 @@ class ViewModel::ActiveRecord < ViewModel::Record
       end
 
     when association_data.collection?
-      associated_viewmodel_class = association_data.viewmodel_class
-      associated_viewmodels = associated.map { |x| associated_viewmodel_class.new(x) }
-      if associated_viewmodel_class._list_member?
+      associated_viewmodels = associated.map do |x|
+        associated_viewmodel_class = association_data.viewmodel_class_for_model!(x.class)
+        associated_viewmodel_class.new(x)
+      end
+
+      # If any associated type is a list member, they must all be
+      if association_data.ordered?
         associated_viewmodels.sort_by!(&:_list_attribute)
       end
+
       associated_viewmodels
 
     else

--- a/lib/view_model/active_record/association_data.rb
+++ b/lib/view_model/active_record/association_data.rb
@@ -196,6 +196,21 @@ class ViewModel::ActiveRecord::AssociationData
     viewmodel_classes.first
   end
 
+  def ordered?
+    @ordered ||=
+      if through?
+        direct_viewmodel._list_member?
+      else
+        list_members = viewmodel_classes.map { |c| c._list_member? }.uniq
+
+        if list_members.size > 1
+          raise ArgumentError.new('Inconsistent associated views: mixed list membership')
+        end
+
+        list_members[0]
+      end
+  end
+
   def through?
     @indirect_association_name.present?
   end

--- a/lib/view_model/active_record/association_manipulation.rb
+++ b/lib/view_model/active_record/association_manipulation.rb
@@ -16,6 +16,8 @@ module ViewModel::ActiveRecord::AssociationManipulation
       associated_viewmodel = association_data.viewmodel_class
       direct_viewmodel     = association_data.direct_viewmodel
     else
+      raise ArgumentError.new('Polymorphic STI relationships not supported yet') if association_data.viewmodel_classes.size > 1
+
       associated_viewmodel = association.klass.try { |k| association_data.viewmodel_class_for_model!(k) }
       direct_viewmodel     = associated_viewmodel
     end
@@ -116,6 +118,8 @@ module ViewModel::ActiveRecord::AssociationManipulation
             direct_viewmodel_class = association_data.direct_viewmodel
             root_update_data, referenced_update_data = construct_indirect_append_updates(association_data, subtree_hashes, references)
           else
+            raise ArgumentError.new('Polymorphic STI relationships not supported yet') if association_data.viewmodel_classes.size > 1
+
             direct_viewmodel_class = association_data.viewmodel_class
             root_update_data, referenced_update_data = construct_direct_append_updates(association_data, subtree_hashes, references)
           end
@@ -238,6 +242,8 @@ module ViewModel::ActiveRecord::AssociationManipulation
           direct_viewmodel = association_data.direct_viewmodel
           association_scope = association_scope.where(association_data.indirect_reflection.foreign_key => associated_id)
         else
+          raise ArgumentError.new('Polymorphic STI relationships not supported yet') if association_data.viewmodel_classes.size > 1
+
           # viewmodel type for current association: nil in case of empty polymorphic association
           direct_viewmodel = association.klass.try { |k| association_data.viewmodel_class_for_model!(k) }
 

--- a/lib/view_model/active_record/association_manipulation.rb
+++ b/lib/view_model/active_record/association_manipulation.rb
@@ -22,7 +22,7 @@ module ViewModel::ActiveRecord::AssociationManipulation
       direct_viewmodel     = associated_viewmodel
     end
 
-    if direct_viewmodel._list_member?
+    if association_data.ordered?
       association_scope = association_scope.order(direct_viewmodel._list_attribute_name)
     end
 
@@ -131,7 +131,7 @@ module ViewModel::ActiveRecord::AssociationManipulation
           update_context.root_updates.each { |update| update.reparent_to = new_parent }
 
           # Set place in list.
-          if direct_viewmodel_class._list_member?
+          if association_data.ordered?
             new_positions = select_append_positions(association_data,
                                                     direct_viewmodel_class._list_attribute_name,
                                                     update_context.root_updates.count,

--- a/lib/view_model/active_record/update_operation.rb
+++ b/lib/view_model/active_record/update_operation.rb
@@ -801,7 +801,7 @@ class ViewModel::ActiveRecord
         ReferencedCollectionMember.new(indirect_viewmodel_ref, direct_vm)
       end
 
-      if direct_viewmodel_class._list_member?
+      if association_data.ordered?
         previous_members.sort_by!(&:position)
       end
 
@@ -867,7 +867,7 @@ class ViewModel::ActiveRecord
         viewmodel.association_changed!(association_data.association_name)
       end
 
-      if direct_viewmodel_class._list_member?
+      if association_data.ordered?
         ActsAsManualList.update_positions(target_collection.members)
       end
 

--- a/lib/view_model/active_record/update_operation.rb
+++ b/lib/view_model/active_record/update_operation.rb
@@ -450,14 +450,13 @@ class ViewModel::ActiveRecord
       parent_data = ParentData.new(association_data.direct_reflection.inverse_of, viewmodel)
 
       # load children already attached to this model
-      child_viewmodel_class = association_data.viewmodel_class
-
       previous_child_viewmodels =
         model.public_send(association_data.direct_reflection.name).map do |child_model|
+          child_viewmodel_class = association_data.viewmodel_class_for_model!(child_model.class)
           child_viewmodel_class.new(child_model)
         end
 
-      if child_viewmodel_class._list_member?
+      if association_data.ordered?
         previous_child_viewmodels.sort_by!(&:_list_attribute)
       end
 
@@ -604,7 +603,7 @@ class ViewModel::ActiveRecord
       # need to be updated anyway since their parent pointer will change.
       new_positions = Array.new(resolved_children.length)
 
-      if association_data.viewmodel_class._list_member?
+      if association_data.ordered?
         set_position = ->(index, pos) { new_positions[index] = pos }
 
         get_previous_position = ->(index) do

--- a/test/unit/view_model/callbacks_test.rb
+++ b/test/unit/view_model/callbacks_test.rb
@@ -494,7 +494,7 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
       let(:callback) { CallbackCrasher.new }
 
       it 'raises the callback error' do
-        proc { serialize(vm) }.must_raise(Crash)
+        _(-> { serialize(vm) }).must_raise(Crash)
       end
 
       describe 'with an access control that rejects' do
@@ -503,7 +503,7 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
         end
 
         it 'fails access control first' do
-          proc { serialize(vm) }.must_raise(ViewModel::AccessControlError)
+          _(-> { serialize(vm) }).must_raise(ViewModel::AccessControlError)
         end
 
         describe 'and a view-mutating callback that crashes' do
@@ -514,7 +514,7 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
           let(:callback) { MutatingCrasher.new }
 
           it 'raises the callback error first' do
-            proc { serialize(vm) }.must_raise(Crash)
+            _(-> { serialize(vm) }).must_raise(Crash)
           end
         end
       end


### PR DESCRIPTION
Previously we assumed a collection association had a single `viewmodel_class`: we could use it to construct a view for a given model, and check it for list membership. With STI polymorphism, it may have multiple viewmodel_classes. We must resolve the viewmodel independently per model, and the list membership must be consistent among the viewmodel_classes. Extend AssociationData to lookup and validate this association ordering.

This does not yet support polymorphism in external AssociationManipulation, but that's consistent with its current behaviour of not supporting through polymorphism.

Additionally including minor fixes to tests and migrations.