### PR TITLE
Fixup: re-add incorrectly removed serialize_context

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.4.1'
+  VERSION = '3.4.2'
 end

--- a/lib/view_model/active_record/nested_controller_base.rb
+++ b/lib/view_model/active_record/nested_controller_base.rb
@@ -15,7 +15,7 @@ module ViewModel::ActiveRecord::NestedControllerBase
       owner_view = owner_viewmodel.find(owner_viewmodel_id, eager_include: false, lock: lock_owner)
       ViewModel::Callbacks.wrap_serialize(owner_view, context: serialize_context) do
         # Association manipulation methods construct child contexts internally
-        associated_views = owner_view.load_associated(association_name, scope: scope)
+        associated_views = owner_view.load_associated(association_name, scope: scope, serialize_context: serialize_context)
 
         associated_views = yield(associated_views) if block_given?
 


### PR DESCRIPTION
`serialize_context` parameter was incorrectly removed from `load_associated` call in `NestedControllerBase` in #164: restore it.