### PR TITLE
Polymorphic association data

### DIFF
--- a/iknow_view_models.gemspec
+++ b/iknow_view_models.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 5.0'
 
   spec.add_dependency 'acts_as_manual_list'
-  spec.add_dependency 'deep_preloader', '>= 1.0.1'
+  spec.add_dependency 'deep_preloader', '>= 1.0.2'
   spec.add_dependency 'iknow_cache'
   spec.add_dependency 'iknow_params', '~> 2.2.0'
   spec.add_dependency 'keyword_builder'

--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.4.2'
+  VERSION = '3.4.3'
 end

--- a/lib/view_model/active_record/association_data.rb
+++ b/lib/view_model/active_record/association_data.rb
@@ -127,7 +127,9 @@ class ViewModel::ActiveRecord::AssociationData
   end
 
   def polymorphic?
-    target_reflection.polymorphic?
+    # STI polymorphism isn't shown on the association reflection, so in that
+    # case we have to infer it by having multiple target viewmodel types.
+    target_reflection.polymorphic? || viewmodel_classes.size > 1
   end
 
   # The side of the immediate association that holds the pointer.

--- a/lib/view_model/active_record/association_manipulation.rb
+++ b/lib/view_model/active_record/association_manipulation.rb
@@ -16,7 +16,7 @@ module ViewModel::ActiveRecord::AssociationManipulation
       associated_viewmodel = association_data.viewmodel_class
       direct_viewmodel     = association_data.direct_viewmodel
     else
-      raise ArgumentError.new('Polymorphic STI relationships not supported yet') if association_data.viewmodel_classes.size > 1
+      raise ArgumentError.new('Polymorphic STI relationships not supported yet') if association_data.polymorphic?
 
       associated_viewmodel = association.klass.try { |k| association_data.viewmodel_class_for_model!(k) }
       direct_viewmodel     = associated_viewmodel
@@ -118,7 +118,7 @@ module ViewModel::ActiveRecord::AssociationManipulation
             direct_viewmodel_class = association_data.direct_viewmodel
             root_update_data, referenced_update_data = construct_indirect_append_updates(association_data, subtree_hashes, references)
           else
-            raise ArgumentError.new('Polymorphic STI relationships not supported yet') if association_data.viewmodel_classes.size > 1
+            raise ArgumentError.new('Polymorphic STI relationships not supported yet') if association_data.polymorphic?
 
             direct_viewmodel_class = association_data.viewmodel_class
             root_update_data, referenced_update_data = construct_direct_append_updates(association_data, subtree_hashes, references)
@@ -242,7 +242,7 @@ module ViewModel::ActiveRecord::AssociationManipulation
           direct_viewmodel = association_data.direct_viewmodel
           association_scope = association_scope.where(association_data.indirect_reflection.foreign_key => associated_id)
         else
-          raise ArgumentError.new('Polymorphic STI relationships not supported yet') if association_data.viewmodel_classes.size > 1
+          raise ArgumentError.new('Polymorphic STI relationships not supported yet') if association_data.polymorphic?
 
           # viewmodel type for current association: nil in case of empty polymorphic association
           direct_viewmodel = association.klass.try { |k| association_data.viewmodel_class_for_model!(k) }

--- a/test/unit/view_model/active_record/has_many_test.rb
+++ b/test/unit/view_model/active_record/has_many_test.rb
@@ -972,7 +972,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
         'children' => [
           { '_type' => 'Dog', 'dog_number' => 1 },
           { '_type' => 'Cat', 'cat_number' => 2 },
-        ]
+        ],
       }
 
       pv = ModelView.deserialize_from_view(view)
@@ -1010,7 +1010,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     it 'functional updates' do
       model = create_model!
 
-      alter_by_view!(ModelView, model) do |view, refs|
+      alter_by_view!(ModelView, model) do |view, _refs|
         view['children'] = build_fupdate do
           append([{ '_type' => 'Cat', 'cat_number' => 100 }])
         end
@@ -1020,6 +1020,18 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
       new_child = model.children.order(:position).last
       assert_kind_of(Cat, new_child)
       assert_equal(100, new_child.cat_number)
+    end
+
+    it 'calculates eager_includes' do
+      includes = viewmodel_class.eager_includes
+      expected = DeepPreloader::Spec.new(
+        'children' => DeepPreloader::PolymorphicSpec.new(
+          {
+            'Dog' => DeepPreloader::Spec.new,
+            'Cat' => DeepPreloader::Spec.new,
+          }))
+
+      assert_equal(includes, expected)
     end
   end
 


### PR DESCRIPTION
Properly mark association_data to STI tables as polymorphic: this is required for example to properly form `eager_includes` preload specs