### PR TITLE
Migrator: skip directly to values in fupdates

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.5.0'
+  VERSION = '3.5.1'
 end


### PR DESCRIPTION
Within functional updates, `_type` is used with a context-aware meaning that doesn't indicate an actual viewmodel of that type: in particular, the values for the `delete` action and the before/after of the append action specify the `_type` of the collection type, but in fact must only be _type/id, not full viewmodels, and must not be migrated.

Handle this structure in the up migrator.