### PR TITLE
Allow inheriting a migration from another viewmodel class

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.5.2'
+  VERSION = '3.5.3'
 end

--- a/lib/view_model/migration.rb
+++ b/lib/view_model/migration.rb
@@ -15,13 +15,14 @@ class ViewModel::Migration
 
   # Tiny DSL for defining migration classes
   class Builder
-    def initialize
+    def initialize(superclass = ViewModel::Migration)
+      @superclass = superclass
       @up_block = nil
       @down_block = nil
     end
 
     def build!
-      migration = Class.new(ViewModel::Migration)
+      migration = Class.new(@superclass)
       migration.define_method(:up, &@up_block) if @up_block
       migration.define_method(:down, &@down_block) if @down_block
       migration


### PR DESCRIPTION
Useful in the case that multiple views are defined on the same underlying data, that underwent the same transformation.