### PR TITLE
Record `changed?` when asserting a mutable value on creation

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.5.3'
+  VERSION = '3.6.0'
 end

--- a/lib/view_model/record.rb
+++ b/lib/view_model/record.rb
@@ -359,12 +359,15 @@ class ViewModel::Record < ViewModel
 
       attribute_changed!(vm_attr_name)
 
-      if attr_data.using_viewmodel? && !value.nil?
-        # Extract model from target viewmodel(s) to attach to our model
-        value = attr_data.map_value(value) { |vm| vm.model }
-      end
+      model_value =
+        if attr_data.using_viewmodel? && !value.nil?
+          # Extract model from target viewmodel(s) to attach to our model
+          attr_data.map_value(value) { |vm| vm.model }
+        else
+          value
+        end
 
-      model.public_send("#{attr_data.model_attr_name}=", value)
+      model.public_send("#{attr_data.model_attr_name}=", model_value)
 
     elsif new_model?
       # Record attribute_changed for mutable values asserted on a new model, even where

--- a/lib/view_model/record.rb
+++ b/lib/view_model/record.rb
@@ -365,6 +365,11 @@ class ViewModel::Record < ViewModel
       end
 
       model.public_send("#{attr_data.model_attr_name}=", value)
+
+    elsif new_model?
+      # Record attribute_changed for mutable values asserted on a new model, even where
+      # they match the ActiveRecord default.
+      attribute_changed!(vm_attr_name) unless attr_data.read_only? && !attr_data.write_once?
     end
 
     if attr_data.using_viewmodel?

--- a/test/helpers/test_access_control.rb
+++ b/test/helpers/test_access_control.rb
@@ -13,6 +13,7 @@ class TestAccessControl < ViewModel::AccessControl
     @editable_checks   = []
     @visible_checks    = []
     @valid_edit_checks = []
+    @changes           = []
   end
 
   # Collect
@@ -31,6 +32,17 @@ class TestAccessControl < ViewModel::AccessControl
   def visible_check(traversal_env)
     @visible_checks << traversal_env.view.to_reference
     ViewModel::AccessControl::Result.new(@can_view)
+  end
+
+  def record_deserialize_changes(ref, changes)
+    @changes << [ref, changes]
+  end
+
+  # Collect all changes on after_deserialize, to allow inspecting changes that
+  # didn't result in `changed?`
+  after_deserialize do
+    ref = view.to_reference
+    record_deserialize_changes(ref, changes)
   end
 
   # Query (also see attr_accessors)
@@ -54,5 +66,11 @@ class TestAccessControl < ViewModel::AccessControl
 
   def was_edited?(ref)
     all_valid_edit_changes(ref).present?
+  end
+
+  def all_changes(ref)
+    @changes
+      .select { |cref, _changes| cref == ref }
+      .map    { |_cref, changes| changes }
   end
 end


### PR DESCRIPTION
Even if it's the model's default value. This allows callbacks and access control to differentiate between an explicitly asserted value and a fallback to the model default.

Also refactors the dummy model in `RecordTest`: previously the "model default values" were anything but that, and couldn't differentiate between a value that was asserted and that was not.

Bumps semantic minor version, as this slightly changes the contract with library users.