### PR TITLE
VM::AccessControl::Composed: allow checkers to return a custom error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ gem 'minitest-ci'
 # Override gemspec for development version preferences
 gem 'activerecord',  '~> 7.0.0'
 gem 'activesupport', '~> 7.0.0'
+gem 'actionpack',    '~> 7.0.0'

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -5,5 +5,6 @@ source 'https://rubygems.org'
 gem 'minitest-ci'
 gem 'activerecord', '~> 5.2.0'
 gem 'activesupport', '~> 5.2.0'
+gem 'actionpack', '~> 5.2.0'
 
 gemspec path: '../'

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -5,5 +5,6 @@ source 'https://rubygems.org'
 gem 'minitest-ci'
 gem 'activerecord', '~> 6.0.0'
 gem 'activesupport', '~> 6.0.0'
+gem 'actionpack', '~> 6.0.0'
 
 gemspec path: '../'

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -5,5 +5,6 @@ source 'https://rubygems.org'
 gem 'minitest-ci'
 gem 'activerecord', '~> 6.1.0'
 gem 'activesupport', '~> 6.1.0'
+gem 'actionpack', '~> 6.1.0'
 
 gemspec path: '../'

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -5,5 +5,6 @@ source "https://rubygems.org"
 gem 'minitest-ci'
 gem "activerecord", "~> 7.0.0"
 gem "activesupport", "~> 7.0.0"
+gem "actionpack", "~> 7.0.0"
 
 gemspec path: '../'

--- a/iknow_view_models.gemspec
+++ b/iknow_view_models.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7'
 
+  spec.add_dependency 'actionpack', '>= 5.0'
   spec.add_dependency 'activerecord', '>= 5.0'
   spec.add_dependency 'activesupport', '>= 5.0'
 

--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.6.1'
+  VERSION = '3.6.2'
 end

--- a/lib/view_model/access_control.rb
+++ b/lib/view_model/access_control.rb
@@ -149,6 +149,14 @@ class ViewModel::AccessControl
   def raise_if_error!(result)
     raise (result.error || yield) unless result.permit?
   end
+
+  # Called from composed access controls via the `env`, this is used to make the
+  # if/unless DSL more readable when returning a custom failure error.
+  def failure(err)
+    raise ArgumentError.new("Unexpected failure type: #{err}") unless err.is_a?(StandardError)
+
+    err
+  end
 end
 
 require 'view_model/access_control/open'

--- a/test/unit/view_model/access_control_test.rb
+++ b/test/unit/view_model/access_control_test.rb
@@ -156,6 +156,21 @@ class ViewModel::AccessControlTest < ActiveSupport::TestCase
       assert_equal(2, ex.reasons.count)
     end
 
+    def test_veto_ordering
+      TestAccessControl.visible_if!('always') { true }
+
+      TestAccessControl.visible_unless!('car starts with i') do
+        view.car =~ /^i/
+      end
+
+      TestAccessControl.visible_unless!('car ends with e') do
+        view.car =~ /e$/
+      end
+
+      assert_serializes(ListView, List.create!(car: 'ok'))
+      refute_serializes(ListView, List.create!(car: 'invisible'), /not permitted.*car starts with i/)
+    end
+
     def test_custom_error_if
       TestAccessControl.visible_if!('car is visible1') do
         view.car == 'visible1' ||

--- a/test/unit/view_model/active_record/cache_test.rb
+++ b/test/unit/view_model/active_record/cache_test.rb
@@ -15,15 +15,10 @@ require 'view_model/active_record'
 
 DUMMY_RAILS_CACHE = ActiveSupport::Cache::MemoryStore.new
 
-module RailsDummyCache
-  def cache
-    DUMMY_RAILS_CACHE
-  end
+IknowCache.configure! do
+  logger ::ActiveRecord::Base.logger
+  cache DUMMY_RAILS_CACHE
 end
-
-# Ensure we have a dummy Rails, and then prepend our dummy cache
-module Rails; end
-Rails.singleton_class.prepend(RailsDummyCache)
 
 class ViewModel::ActiveRecord
   class CacheTest < ActiveSupport::TestCase


### PR DESCRIPTION
A custom error is signaled by returning `failure(AnErrorObject)` from a checker body.

In the case of `unless` checkers, this error is guaranteed to be raised.
In the case of `if` checkers, the first custom error to be returned (if any) will be raised if all `if` checkers fail.