### PR TITLE
AccessControl::Tree: fix inheritance of root children checks

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.6.3'
+  VERSION = '3.6.4'
 end

--- a/lib/view_model/access_control/composed.rb
+++ b/lib/view_model/access_control/composed.rb
@@ -175,11 +175,10 @@ class ViewModel::AccessControl::Composed < ViewModel::AccessControl
     end
 
     def inspect
-      s = super + '('
-      s += inspect_checks.join(', ')
-      s += " includes checkers: #{@included_checkers.inspect}" if @included_checkers.present?
-      s += ')'
-      s
+      checks = inspect_checks
+      checks << "includes checkers: #{@included_checkers.inspect}" if @included_checkers.present?
+
+      super + '(' + checks.join(', ') + ')'
     end
 
     def inspect_checks

--- a/lib/view_model/access_control/tree.rb
+++ b/lib/view_model/access_control/tree.rb
@@ -192,8 +192,6 @@ class ViewModel::AccessControl::Tree < ViewModel::AccessControl
       def inspect_checks
         checks = super
         if root?
-          checks << 'no root checks'
-        else
           checks << "root_children_visible_if: #{root_children_visible_ifs.map(&:reason)}"            if root_children_visible_ifs.present?
           checks << "root_children_visible_unless: #{root_children_visible_unlesses.map(&:reason)}"   if root_children_visible_unlesses.present?
           checks << "root_children_editable_if: #{root_children_editable_ifs.map(&:reason)}"          if root_children_editable_ifs.present?
@@ -252,16 +250,16 @@ class ViewModel::AccessControl::Tree < ViewModel::AccessControl
 
     def save_root_visibility!(traversal_env)
       result = check_delegates(traversal_env,
-                               self.class.each_check(:root_children_visible_ifs,      ->(a) { a.is_a?(Node) }),
-                               self.class.each_check(:root_children_visible_unlesses, ->(a) { a.is_a?(Node) }))
+                               self.class.each_check(:root_children_visible_ifs,      ->(a) { a < Node }),
+                               self.class.each_check(:root_children_visible_unlesses, ->(a) { a < Node }))
 
       store_descendent_visibility(traversal_env.view, result)
     end
 
     def save_root_editability!(traversal_env)
       result = check_delegates(traversal_env,
-                               self.class.each_check(:root_children_editable_ifs,      ->(a) { a.is_a?(Node) }),
-                               self.class.each_check(:root_children_editable_unlesses, ->(a) { a.is_a?(Node) }))
+                               self.class.each_check(:root_children_editable_ifs,      ->(a) { a < Node }),
+                               self.class.each_check(:root_children_editable_unlesses, ->(a) { a < Node }))
 
       store_descendent_editability(traversal_env.view, result)
     end

--- a/test/unit/view_model/access_control_test.rb
+++ b/test/unit/view_model/access_control_test.rb
@@ -319,6 +319,26 @@ class ViewModel::AccessControlTest < ActiveSupport::TestCase
       assert_serializes(Tree1View, make_tree('rule:visible_children', 'visible child', 'rule:visible_children', 'visible child'))
     end
 
+    def test_root_inheritance
+      parent_access_control = Class.new(ViewModel::AccessControl::Tree)
+      parent_access_control.view 'Tree1' do
+        visible_if!('true') { true }
+
+        root_children_visible_if!('root children visible') do
+          view.val == 'rule:visible_children'
+        end
+      end
+
+      TestAccessControl.include_from(parent_access_control)
+
+      refute_serializes(Tree1View, make_tree('arbitrary parent',      'invisible child'))
+      assert_serializes(Tree1View, make_tree('rule:visible_children', 'visible child'))
+
+      # nested root
+      refute_serializes(Tree1View, make_tree('rule:visible_children', 'visible child', 'arbitrary parent',      'invisible child'))
+      assert_serializes(Tree1View, make_tree('rule:visible_children', 'visible child', 'rule:visible_children', 'visible child'))
+    end
+
     def test_visibility_veto_from_root
       TestAccessControl.view 'Tree1' do
         root_children_visible_unless!('root children invisible') do


### PR DESCRIPTION
Additionally, improve `inspect` for composed nodes.