### PR TITLE
AccessControl::Composed: recurse with include_ancestor predicate

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.6.4'
+  VERSION = '3.6.5'
 end

--- a/lib/view_model/access_control/composed.rb
+++ b/lib/view_model/access_control/composed.rb
@@ -170,7 +170,7 @@ class ViewModel::AccessControl::Composed < ViewModel::AccessControl
         next unless visited.add?(ancestor)
         next if include_ancestor && !include_ancestor.call(ancestor)
 
-        ancestor.each_check(check_name) { |x| yield x }
+        ancestor.each_check(check_name, include_ancestor) { |x| yield x }
       end
     end
 


### PR DESCRIPTION
Otherwise inherited ancestors beyond the immediate parent won't be correctly checked for exclusion