### PR TITLE
Callback environment: forward kwargs to callbacks instance methods

### DIFF
--- a/iknow_view_models.gemspec
+++ b/iknow_view_models.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 2.7.3'
 
   spec.add_dependency 'actionpack', '>= 5.0'
   spec.add_dependency 'activerecord', '>= 5.0'

--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.6.7'
+  VERSION = '3.6.8'
 end

--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.6.8'
+  VERSION = '3.7.0'
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -303,12 +303,12 @@ class ViewModel
     end
   end
 
-  def to_hash(serialize_context: self.class.new_serialize_context)
+  def serialize_to_hash(serialize_context: self.class.new_serialize_context)
     Jbuilder.new { |json| serialize(json, serialize_context: serialize_context) }.attributes!
   end
 
   def to_json(serialize_context: self.class.new_serialize_context)
-    ViewModel.encode_json(self.to_hash(serialize_context: serialize_context))
+    ViewModel.encode_json(self.serialize_to_hash(serialize_context: serialize_context))
   end
 
   # Render this viewmodel to a jBuilder. Usually overridden in subclasses.

--- a/lib/view_model/callbacks.rb
+++ b/lib/view_model/callbacks.rb
@@ -11,9 +11,9 @@ module ViewModel::Callbacks
   # callbacks instance with additional instance method access to the view,
   # context and extra context-dependent parameters.
   module CallbackEnvContext
-    def method_missing(method, *args, &block)
+    def method_missing(method, ...)
       if _callbacks.respond_to?(method, true)
-        _callbacks.send(method, *args, &block)
+        _callbacks.send(method, ...)
       else
         super
       end

--- a/test/helpers/arvm_test_utilities.rb
+++ b/test/helpers/arvm_test_utilities.rb
@@ -98,7 +98,7 @@ module ARVMTestUtilities
   end
 
   def assert_serializes(vm, model, serialize_context: vm.new_serialize_context)
-    h = vm.new(model).to_hash(serialize_context: serialize_context)
+    h = vm.new(model).serialize_to_hash(serialize_context: serialize_context)
     assert_kind_of(Hash, h)
     refs = serialize_context.serialize_references_to_hash
     assert_kind_of(Hash, refs)
@@ -106,7 +106,7 @@ module ARVMTestUtilities
 
   def refute_serializes(vm, model, message = nil, serialize_context: vm.new_serialize_context)
     ex = assert_raises(ViewModel::AccessControlError) do
-      vm.new(model).to_hash(serialize_context: serialize_context)
+      vm.new(model).serialize_to_hash(serialize_context: serialize_context)
       serialize_context.serialize_references_to_hash
     end
     assert_match(message, ex.message) if message

--- a/test/unit/view_model/active_record/controller_nested_test.rb
+++ b/test/unit/view_model/active_record/controller_nested_test.rb
@@ -44,7 +44,7 @@ class ViewModel::ActiveRecord::ControllerNestedTest < ActiveSupport::TestCase
     assert_equal(200, childcontroller.status)
 
     expected_children = @parent.children
-    assert_equal({ 'data' => expected_children.map { |c| ChildView.new(c).to_hash } },
+    assert_equal({ 'data' => expected_children.map { |c| ChildView.new(c).serialize_to_hash } },
       childcontroller.hash_response)
 
     assert_all_hooks_nested_inside_parent_hook(childcontroller.hook_trace)
@@ -59,7 +59,7 @@ class ViewModel::ActiveRecord::ControllerNestedTest < ActiveSupport::TestCase
     assert_equal(200, childcontroller.status)
 
     expected_children = @parent.children + distractor.children
-    assert_equal({ 'data' => expected_children.map { |c| ChildView.new(c).to_hash } },
+    assert_equal({ 'data' => expected_children.map { |c| ChildView.new(c).serialize_to_hash } },
       childcontroller.hash_response)
   end
 
@@ -79,7 +79,7 @@ class ViewModel::ActiveRecord::ControllerNestedTest < ActiveSupport::TestCase
     @parent.reload
 
     assert_equal(%w[c1 c2 c3], @parent.children.order(:position).pluck(:name))
-    assert_equal({ 'data' => ChildView.new(@parent.children.last).to_hash },
+    assert_equal({ 'data' => ChildView.new(@parent.children.last).serialize_to_hash },
       childcontroller.hash_response)
 
     assert_all_hooks_nested_inside_parent_hook(childcontroller.hook_trace)
@@ -102,7 +102,7 @@ class ViewModel::ActiveRecord::ControllerNestedTest < ActiveSupport::TestCase
     @parent.reload
 
     assert_equal(%w[c1 c2 c3 c4], @parent.children.order(:position).pluck(:name))
-    new_children_hashes = @parent.children.last(2).map { |c| ChildView.new(c).to_hash }
+    new_children_hashes = @parent.children.last(2).map { |c| ChildView.new(c).serialize_to_hash }
     assert_equal({ 'data' => new_children_hashes },
       childcontroller.hash_response)
 
@@ -265,7 +265,7 @@ class ViewModel::ActiveRecord::ControllerNestedTest < ActiveSupport::TestCase
     old_child.reload
 
     assert_equal('new_name', old_child.name)
-    assert_equal({ 'data' => ChildView.new(old_child).to_hash },
+    assert_equal({ 'data' => ChildView.new(old_child).serialize_to_hash },
       childcontroller.hash_response)
   end
 
@@ -275,7 +275,7 @@ class ViewModel::ActiveRecord::ControllerNestedTest < ActiveSupport::TestCase
     childcontroller = ChildController.new(params: { id: old_child.id })
     childcontroller.invoke(:show)
 
-    assert_equal({ 'data' => ChildView.new(old_child).to_hash },
+    assert_equal({ 'data' => ChildView.new(old_child).serialize_to_hash },
       childcontroller.hash_response)
 
     assert_equal(200, childcontroller.status)
@@ -323,7 +323,7 @@ class ViewModel::ActiveRecord::ControllerNestedTest < ActiveSupport::TestCase
 
     assert_equal(200, labelcontroller.status, labelcontroller.hash_response)
 
-    assert_equal({ 'data' => LabelView.new(old_label).to_hash },
+    assert_equal({ 'data' => LabelView.new(old_label).serialize_to_hash },
       labelcontroller.hash_response)
 
     assert_all_hooks_nested_inside_parent_hook(labelcontroller.hook_trace)
@@ -367,7 +367,7 @@ class ViewModel::ActiveRecord::ControllerNestedTest < ActiveSupport::TestCase
     old_label.reload
 
     assert_equal('new label', old_label.text)
-    assert_equal({ 'data' => LabelView.new(old_label).to_hash },
+    assert_equal({ 'data' => LabelView.new(old_label).serialize_to_hash },
       labelcontroller.hash_response)
 
     assert_all_hooks_nested_inside_parent_hook(labelcontroller.hook_trace)
@@ -381,7 +381,7 @@ class ViewModel::ActiveRecord::ControllerNestedTest < ActiveSupport::TestCase
 
     assert_equal(200, labelcontroller.status, labelcontroller.hash_response)
 
-    assert_equal({ 'data' => LabelView.new(old_label).to_hash },
+    assert_equal({ 'data' => LabelView.new(old_label).serialize_to_hash },
       labelcontroller.hash_response)
   end
 
@@ -414,7 +414,7 @@ class ViewModel::ActiveRecord::ControllerNestedTest < ActiveSupport::TestCase
     old_label.reload
 
     assert_equal('new label', old_label.text)
-    assert_equal({ 'data' => LabelView.new(old_label).to_hash },
+    assert_equal({ 'data' => LabelView.new(old_label).serialize_to_hash },
       labelcontroller.hash_response)
   end
 
@@ -472,11 +472,11 @@ class ViewModel::ActiveRecord::ControllerNestedTest < ActiveSupport::TestCase
           'updates' => [
             {
               'id'     => @parent.id,
-              'update' => TargetView.new(target).to_hash,
+              'update' => TargetView.new(target).serialize_to_hash,
             },
             {
               'id'     => other_parent.id,
-              'update' => TargetView.new(other_target).to_hash,
+              'update' => TargetView.new(other_target).serialize_to_hash,
             },
           ].sort_by { |x| x.fetch('id') }
         }
@@ -535,7 +535,7 @@ class ViewModel::ActiveRecord::ControllerNestedTest < ActiveSupport::TestCase
 
     assert_equal(
       {
-        ref_key => CategoryView.new(@parent.category).to_hash,
+        ref_key => CategoryView.new(@parent.category).serialize_to_hash,
       },
       references,
     )
@@ -591,7 +591,7 @@ class ViewModel::ActiveRecord::ControllerNestedTest < ActiveSupport::TestCase
 
     assert_equal(
       {
-        ref_key => TagView.new(@parent.parent_tags.first.tag).to_hash,
+        ref_key => TagView.new(@parent.parent_tags.first.tag).serialize_to_hash,
       },
       references,
     )

--- a/test/unit/view_model/active_record/controller_test.rb
+++ b/test/unit/view_model/active_record/controller_test.rb
@@ -37,7 +37,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     parentcontroller = ParentController.new(params: { id: @parent.id })
     parentcontroller.invoke(:show)
 
-    assert_equal({ 'data' => @parent_view.to_hash },
+    assert_equal({ 'data' => @parent_view.serialize_to_hash },
                  parentcontroller.hash_response)
 
     assert_equal(200, parentcontroller.status)
@@ -52,7 +52,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
 
     parentcontroller.invoke(:show)
 
-    expected_view = @parent_view.to_hash
+    expected_view = @parent_view.serialize_to_hash
                       .except('name')
                       .merge('old_name' => @parent.name,
                              ViewModel::VERSION_ATTRIBUTE => 1,
@@ -88,7 +88,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     assert_equal(200, parentcontroller.status)
 
     assert_equal(parentcontroller.hash_response,
-                 { 'data' => [@parent_view.to_hash, p2_view.to_hash] })
+                 { 'data' => [@parent_view.serialize_to_hash, p2_view.serialize_to_hash] })
 
     assert_all_hooks_nested_inside_parent_hook(parentcontroller.hook_trace)
   end
@@ -112,7 +112,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     p2_view = ParentView.new(p2)
     assert(p2.present?, 'p2 created')
 
-    assert_equal({ 'data' => p2_view.to_hash }, parentcontroller.hash_response)
+    assert_equal({ 'data' => p2_view.serialize_to_hash }, parentcontroller.hash_response)
 
     assert_all_hooks_nested_inside_parent_hook(parentcontroller.hook_trace)
   end
@@ -160,7 +160,7 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
     @parent.reload
 
     assert_equal('new', @parent.name)
-    assert_equal({ 'data' => @parent_view.to_hash },
+    assert_equal({ 'data' => @parent_view.serialize_to_hash },
                  parentcontroller.hash_response)
 
     assert_all_hooks_nested_inside_parent_hook(parentcontroller.hook_trace)

--- a/test/unit/view_model/active_record/customization_test.rb
+++ b/test/unit/view_model/active_record/customization_test.rb
@@ -283,13 +283,13 @@ class ViewModel::ActiveRecord::FlattenAssociationTest < ActiveSupport::TestCase
 
   def test_serialize
     v = SectionView.new(@simplesection)
-    assert_equal(@simplesection_view, v.to_hash)
+    assert_equal(@simplesection_view, v.serialize_to_hash)
 
     v = SectionView.new(@quizsection)
-    assert_equal(@quizsection_view, v.to_hash)
+    assert_equal(@quizsection_view, v.serialize_to_hash)
 
     v = SectionView.new(@vocabsection)
-    assert_equal(@vocabsection_view, v.to_hash)
+    assert_equal(@vocabsection_view, v.serialize_to_hash)
   end
 
   def new_view_like(view)

--- a/test/unit/view_model/active_record/has_many_test.rb
+++ b/test/unit/view_model/active_record/has_many_test.rb
@@ -469,8 +469,8 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
     old_children = @model1.children.order(:position)
     moved_child = old_children[1]
 
-    view = viewmodel_class.new(@model2).to_hash
-    view['children'] << child_viewmodel_class.new(moved_child).to_hash
+    view = viewmodel_class.new(@model2).serialize_to_hash
+    view['children'] << child_viewmodel_class.new(moved_child).serialize_to_hash
 
     retained_children = old_children - [moved_child]
     release_view = { '_type' => 'Model', 'id' => @model1.id,
@@ -503,7 +503,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
   def test_has_many_append_and_update_existing_association
     child = @model1.children[1]
 
-    cv = child_viewmodel_class.new(child).to_hash
+    cv = child_viewmodel_class.new(child).serialize_to_hash
     cv['name'] = 'newname'
 
     viewmodel_class.new(@model1).append_associated(:children, cv)
@@ -558,7 +558,7 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
   def test_move_and_edit_child_to_new
     child = @model1.children[1]
 
-    child_view = child_viewmodel_class.new(child).to_hash
+    child_view = child_viewmodel_class.new(child).serialize_to_hash
     child_view['name'] = 'changed'
 
     view = { '_type' => 'Model',
@@ -592,9 +592,9 @@ class ViewModel::ActiveRecord::HasManyTest < ActiveSupport::TestCase
   def test_move_and_edit_child_to_existing
     old_child = @model1.children[1]
 
-    old_child_view = child_viewmodel_class.new(old_child).to_hash
+    old_child_view = child_viewmodel_class.new(old_child).serialize_to_hash
     old_child_view['name'] = 'changed'
-    view = viewmodel_class.new(@model2).to_hash
+    view = viewmodel_class.new(@model2).serialize_to_hash
     view['children'] << old_child_view
 
     release_view = { '_type' => 'Model', 'id' => @model1.id,

--- a/test/unit/view_model/active_record_test.rb
+++ b/test/unit/view_model/active_record_test.rb
@@ -146,7 +146,7 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
     assert_raises(ViewModel::AccessControlError) do
       no_view_context = ViewModelBase.new_serialize_context(can_view: false)
-      parentview.to_hash(serialize_context: no_view_context)
+      parentview.serialize_to_hash(serialize_context: no_view_context)
     end
 
     assert_raises(ViewModel::AccessControlError) do
@@ -191,7 +191,7 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
     ex = assert_raises(ViewModel::AccessControlError) do
       # edit
-      v = ParentView.new(@parent1).to_hash.merge('name' => 'p2')
+      v = ParentView.new(@parent1).serialize_to_hash.merge('name' => 'p2')
       ParentView.deserialize_from_view(v, deserialize_context: no_edit_context)
     end
     assert_match(/Illegal edit/, ex.message)
@@ -214,7 +214,7 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
 
     ex = assert_raises(ViewModel::AccessControlError) do
       # edit
-      v = ParentView.new(@parent1).to_hash.merge('name' => 'p2')
+      v = ParentView.new(@parent1).serialize_to_hash.merge('name' => 'p2')
       ParentView.deserialize_from_view(v, deserialize_context: no_edit_context)
     end
     assert_match(/Illegal edit/, ex.message)

--- a/test/unit/view_model/callbacks_test.rb
+++ b/test/unit/view_model/callbacks_test.rb
@@ -554,6 +554,35 @@ class ViewModel::CallbacksTest < ActiveSupport::TestCase
       end
     end
 
+    describe 'delegates to methods on the callback object' do
+      class TestCallback
+        include ViewModel::Callbacks
+
+        attr_reader :a_args, :b_args
+
+        def a(*args)
+          @a_args = args
+        end
+
+        def b(*args, **kwargs)
+          @b_args = [args, kwargs]
+        end
+
+        before_visit do
+          a(1, 2, x: 1, y: 2)
+          b(1, 2, x: 1, y: 2)
+        end
+      end
+
+      let(:callback) { TestCallback.new }
+
+      it 'delegates to callback methods including kwargs' do
+        serialize(vm)
+        value(callback.a_args).must_equal([1, 2, { x: 1, y: 2 }])
+        value(callback.b_args).must_equal([[1, 2], { x: 1, y: 2 }])
+      end
+    end
+
     describe 'provides details to the execution environment' do
       class EnvCallback
         include ViewModel::Callbacks

--- a/test/unit/view_model/record_test.rb
+++ b/test/unit/view_model/record_test.rb
@@ -204,7 +204,7 @@ class ViewModel::RecordTest < ActiveSupport::TestCase
       def self.included(base)
         base.instance_eval do
           it 'can serialize to the expected view' do
-            h = viewmodel_class.new(subject_model).to_hash
+            h = viewmodel_class.new(subject_model).serialize_to_hash
             assert_equal(expected_view, h)
           end
         end
@@ -318,7 +318,7 @@ class ViewModel::RecordTest < ActiveSupport::TestCase
       it 'raises correctly on an undeserializable value' do
         bad_model = subject_model.tap { |m| m.moment = 2.7 }
         ex = assert_raises(ViewModel::SerializationError) do
-          viewmodel_class.new(bad_model).to_hash
+          viewmodel_class.new(bad_model).serialize_to_hash
         end
         assert_match(/Could not serialize invalid value.*'moment'.*Incorrect type/, ex.detail)
       end


### PR DESCRIPTION
* When forwarding method calls made within a callbacks environment to the Callbacks instance, use ... forwarding to include keyword arguments. Requires Ruby 2.7.3.

* ViewModel#to_hash collides with Ruby's implicit type coercion method, which is really not at all what we wanted. In particular, this may mean attempting to coerce a viewmodel to a hash for keyword arguments when passed as the last argument in Ruby 2.7. Rename to #serialize_to_hash to match the class method. This change is backwards incompatible, so bump the minor version.
