### PR TITLE
Fix migrations adding references

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.7.0'
+  VERSION = '3.7.1'
 end

--- a/lib/view_model/reference.rb
+++ b/lib/view_model/reference.rb
@@ -29,5 +29,13 @@ class ViewModel
     def hash
       [viewmodel_class, model_id].hash
     end
+
+    # Generate a stable reference key for this viewmodel using type name and id
+    def stable_reference
+      raise RuntimeError.new('Model id required to generate a stable reference') unless model_id
+
+      hash = Digest::SHA256.base64digest("#{viewmodel_class.name}.#{model_id}")
+      "ref:h:#{hash}"
+    end
   end
 end

--- a/lib/view_model/references.rb
+++ b/lib/view_model/references.rb
@@ -37,12 +37,13 @@ class ViewModel
 
     private
 
-    # Ensure stable reference ids for the same (persisted) viewmodels.
+    # Ensure stable reference keys for the same (persisted) viewmodels. For
+    # unpersisted viewmodels, use a counter to generate a reference key unique
+    # to this serialization.
     def new_ref!(viewmodel)
       vm_ref = viewmodel.to_reference
       if vm_ref.model_id
-        hash = Digest::SHA256.base64digest("#{vm_ref.viewmodel_class.name}.#{vm_ref.model_id}")
-        "ref:h:#{hash}"
+        vm_ref.stable_reference
       else
         format('ref:i:%06<count>d', count: (@last_ref += 1))
       end

--- a/test/helpers/viewmodel_spec_helpers.rb
+++ b/test/helpers/viewmodel_spec_helpers.rb
@@ -295,6 +295,14 @@ module ViewModelSpecHelpers
     end
   end
 
+  module ReferencedList
+    extend ActiveSupport::Concern
+    include ViewModelSpecHelpers::List
+    def model_attributes
+      super.merge(viewmodel: ->(_v) { root! })
+    end
+  end
+
   module ParentAndHasOneChild
     extend ActiveSupport::Concern
     include ViewModelSpecHelpers::Base


### PR DESCRIPTION
Migrations adding references could result in concurrent modification errors if a reference was already being visited. Support this properly, and ensure that the thus-added references are themselves visited for migration.