### PR TITLE
Add configuration for deferred constraints via deserialize context

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.7.2'
+  VERSION = '3.7.3'
 end

--- a/lib/view_model/active_record/update_context.rb
+++ b/lib/view_model/active_record/update_context.rb
@@ -163,7 +163,7 @@ class ViewModel::ActiveRecord
 
       @release_pool.release_all!
 
-      if updated_viewmodels.present?
+      if updated_viewmodels.present? && deserialize_context.validate_deferred_constraints?
         # Deferred database constraints may have been violated by changes during
         # deserialization. VM::AR promises that any errors during deserialization
         # will be raised as a ViewModel::DeserializationError, so check constraints

--- a/lib/view_model/deserialize_context.rb
+++ b/lib/view_model/deserialize_context.rb
@@ -4,9 +4,21 @@ require 'view_model/traversal_context'
 
 class ViewModel::DeserializeContext < ViewModel::TraversalContext
   class SharedContext < ViewModel::TraversalContext::SharedContext
+    def initialize(validate_deferred_constraints: true, **rest)
+      super(**rest)
+      @validate_deferred_constraints = validate_deferred_constraints
+    end
+
+    # Should deferred database constraints be checked via SET CONSTRAINTS
+    # IMMEDIATE at the end of the deserialization operation
+    def validate_deferred_constraints?
+      @validate_deferred_constraints
+    end
   end
 
   def self.shared_context_class
     SharedContext
   end
+
+  delegate :validate_deferred_constraints?, to: :shared_context
 end


### PR DESCRIPTION
Usually, we want to validate deferred database constraints during a deserialization operation to catch and wrap any errors that we caused. Occasionally, if the deserialization is not the entire operation, we want to defer this validation until after all changes have been completed. Add a flag to DeserializeContext::SharedContext to control automatic validation, enabled by default.