### PR TITLE
[v2.x] Fix argument forwarding

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -2,7 +2,7 @@ name: Publish Ruby Gem
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "v2.x" ]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
         include:
           - ruby-version: '2.7'
             bundle-gemfile: gemfiles/rails_5_2.gemfile
+          - ruby-version: '3.0'
+            bundle-gemfile: gemfiles/rails_6_0.gemfile
+          - ruby-version: '3.1'
+            bundle-gemfile: gemfiles/rails_6_1.gemfile
+          - ruby-version: '3.2'
+            bundle-gemfile: gemfiles/rails_7_0.gemfile
 
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.bundle-gemfile }}

--- a/Appraisals
+++ b/Appraisals
@@ -2,3 +2,18 @@ appraise 'rails-5-2' do
   gem 'activerecord', '~> 5.2.0'
   gem 'activesupport', '~> 5.2.0'
 end
+
+appraise 'rails-6-0' do
+  gem 'activerecord', '~> 6.0.0'
+  gem 'activesupport', '~> 6.0.0'
+end
+
+appraise 'rails-6-1' do
+  gem 'activerecord', '~> 6.1.0'
+  gem 'activesupport', '~> 6.1.0'
+end
+
+appraise 'rails-7-0' do
+  gem 'activerecord', '~> 7.0.0'
+  gem 'activesupport', '~> 7.0.0'
+end

--- a/iknow_view_models.gemspec
+++ b/iknow_view_models.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.7.3'
+
   spec.add_dependency "activerecord", ">= 5.0"
   spec.add_dependency "activesupport", ">= 5.0"
 

--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '2.9.0'
+  VERSION = '2.10.0'
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -209,16 +209,16 @@ class ViewModel
       ViewModel::SerializeContext
     end
 
-    def new_serialize_context(*args)
-      serialize_context_class.new(*args)
+    def new_serialize_context(...)
+      serialize_context_class.new(...)
     end
 
     def deserialize_context_class
       ViewModel::DeserializeContext
     end
 
-    def new_deserialize_context(*args)
-      deserialize_context_class.new(*args)
+    def new_deserialize_context(...)
+      deserialize_context_class.new(...)
     end
 
     def accepts_schema_version?(schema_version)

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -3,6 +3,7 @@
 # A ViewModel encapsulates a particular aggregation of data calculated via the
 # underlying models and provides a means of serializing it into views.
 require 'jbuilder'
+require 'base64'
 require 'deep_preloader'
 
 class ViewModel

--- a/lib/view_model/callbacks.rb
+++ b/lib/view_model/callbacks.rb
@@ -11,9 +11,9 @@ module ViewModel::Callbacks
   # callbacks instance with additional instance method access to the view,
   # context and extra context-dependent parameters.
   module CallbackEnvContext
-    def method_missing(method, *args, &block)
+    def method_missing(method, ...)
       if _callbacks.respond_to?(method, true)
-        _callbacks.send(method, *args, &block)
+        _callbacks.send(method, ...)
       else
         super
       end

--- a/lib/view_model/test_helpers/arvm_builder.rb
+++ b/lib/view_model/test_helpers/arvm_builder.rb
@@ -62,8 +62,10 @@ class ViewModel::TestHelpers::ARVMBuilder
     ActiveRecord::Base.connection.execute("DROP TABLE IF EXISTS #{name.underscore.pluralize} CASCADE")
     namespace.send(:remove_const, name)
     namespace.send(:remove_const, viewmodel_name) if viewmodel
-    # prevent cached old class from being used to resolve associations
-    ActiveSupport::Dependencies::Reference.clear!
+    if ActiveSupport::VERSION::MAJOR < 7
+      # prevent cached old class from being used to resolve associations
+      ActiveSupport::Dependencies::Reference.clear!
+    end
   end
 
   private

--- a/lib/view_model/traversal_context.rb
+++ b/lib/view_model/traversal_context.rb
@@ -23,8 +23,8 @@ class ViewModel::TraversalContext
   attr_reader :shared_context
   delegate :access_control, :callbacks, to: :shared_context
 
-  def self.new_child(*args)
-    self.allocate.tap { |c| c.initialize_as_child(*args) }
+  def self.new_child(...)
+    self.allocate.tap { |c| c.initialize_as_child(...) }
   end
 
   def initialize(shared_context: nil, **shared_context_params)

--- a/test/helpers/controller_test_helpers.rb
+++ b/test/helpers/controller_test_helpers.rb
@@ -267,7 +267,9 @@ module ControllerTestControllers
     [:ParentController, :ChildController, :LabelController, :TargetController].each do |name|
       Object.send(:remove_const, name)
     end
-    ActiveSupport::Dependencies::Reference.clear!
+    if ActiveSupport::VERSION::MAJOR < 7
+      ActiveSupport::Dependencies::Reference.clear!
+    end
     super
   end
 end


### PR DESCRIPTION
In particular new_serialize_context should forward keyword arguments instead of relying on `*args` to handle keyword arguments. While we're here though, use `...` where possible, taking hints from the mainline branch.

---

~We don't have any CI at the moment. See #189, and the back port to `v2.x` #191.~