### PR TITLE
gemspec: relax version range of iknow_params

### DIFF
--- a/iknow_view_models.gemspec
+++ b/iknow_view_models.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "acts_as_manual_list"
   spec.add_dependency "deep_preloader"
   spec.add_dependency "iknow_cache"
-  spec.add_dependency "iknow_params", "~> 2.2.0"
+  spec.add_dependency "iknow_params", ">= 2.2.0", "< 2.4"
   spec.add_dependency "safe_values"
   spec.add_dependency "keyword_builder"
 

--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '2.10.0'
+  VERSION = '2.10.1'
 end


### PR DESCRIPTION
It seems like different bundler versions find different solutions. Some use iknow_view_models 2.8.4 with iknow_params 2.3.0, and some use iknow_view_models 2.10.0 with iknow_params 2.2.0. It's probably some heuristic about which package is best to be out of date. Let's just avoid all this confusion by using the latest iknow_params.