### PR TITLE
VM::Controller: add hook to render metadata in the same context

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.7.3'
+  VERSION = '3.8.0'
 end

--- a/lib/view_model/controller.rb
+++ b/lib/view_model/controller.rb
@@ -24,6 +24,8 @@ module ViewModel::Controller
         ViewModel.serialize(viewmodel, json, serialize_context: serialize_context)
       end
 
+      render_response_metadata(json, serialize_context: serialize_context)
+
       if serialize_context && serialize_context.has_references?
         json.references do
           serialize_context.serialize_references(json)
@@ -32,6 +34,9 @@ module ViewModel::Controller
 
       yield(json) if block_given?
     end
+  end
+
+  def render_response_metadata(json, serialize_context:)
   end
 
   # Render an arbitrarily nested tree of hashes and arrays with pre-rendered


### PR DESCRIPTION
This would permit metadata serialization to contribute referenced viewmodels.