### PR TITLE
ErrorView: Add honeybadger context to dev exception view if present

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.7.3'
+  VERSION = '3.7.4'
 end

--- a/lib/view_model/error_view.rb
+++ b/lib/view_model/error_view.rb
@@ -12,11 +12,19 @@ class ViewModel::ErrorView < ViewModel::Record
     def serialize_view(json, serialize_context: nil)
       json.set! :class, exception.class.name
       json.backtrace exception.backtrace
-      if (cause = exception.cause)
-        json.cause do
-          json.set! :class, cause.class.name
-          json.backtrace cause.backtrace
-        end
+
+      json.cause do
+        cause = exception.cause
+        next json.null! unless cause
+
+        json.set! :class, cause.class.name
+        json.backtrace cause.backtrace
+      end
+
+      json.context do
+        next json.null! unless exception.respond_to?(:to_honeybadger_context)
+
+        json.merge! cause.to_honeybadger_context
       end
     end
   end


### PR DESCRIPTION
Also updates the `cause` field to better follow viewmodel API expectations by always including the property whether or not it has a value.