### PR TITLE
Fixup: use correct exception for honeybadger context

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.7.4'
+  VERSION = '3.7.5'
 end

--- a/lib/view_model/error_view.rb
+++ b/lib/view_model/error_view.rb
@@ -24,7 +24,7 @@ class ViewModel::ErrorView < ViewModel::Record
       json.context do
         next json.null! unless exception.respond_to?(:to_honeybadger_context)
 
-        json.merge! cause.to_honeybadger_context
+        json.merge! exception.to_honeybadger_context
       end
     end
   end


### PR DESCRIPTION
There's not always a `cause` (and even if there were, it's not in scope).