### PR TITLE
Reference only handling

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.11.0'
+  VERSION = '3.12.0'
 end

--- a/lib/view_model/active_record/update_data.rb
+++ b/lib/view_model/active_record/update_data.rb
@@ -522,6 +522,10 @@ class ViewModel::ActiveRecord
 
     delegate :new?, :child_update?, :auto_child_update?, to: :metadata
 
+    def reference_only?
+      attributes.empty? && associations.empty? && referenced_associations.empty?
+    end
+
     def self.parse_hashes(root_subtree_hashes, referenced_subtree_hashes = {})
       valid_reference_keys = referenced_subtree_hashes.keys.to_set
 

--- a/lib/view_model/migration.rb
+++ b/lib/view_model/migration.rb
@@ -5,8 +5,18 @@ class ViewModel::Migration
   require 'view_model/migration/one_way_error'
   require 'view_model/migration/unspecified_version_error'
 
+  REFERENCE_ONLY_KEYS = [
+    ViewModel::TYPE_ATTRIBUTE,
+    ViewModel::ID_ATTRIBUTE,
+    ViewModel::VERSION_ATTRIBUTE,
+  ].freeze
+
   def up(view, _references)
-    raise ViewModel::Migration::OneWayError.new(view[ViewModel::TYPE_ATTRIBUTE], :up)
+    # Only a reference-only view may be (trivially) migrated up without an
+    # explicit migration.
+    if (view.keys - REFERENCE_ONLY_KEYS).present?
+      raise ViewModel::Migration::OneWayError.new(view[ViewModel::TYPE_ATTRIBUTE], :up)
+    end
   end
 
   def down(view, _references)


### PR DESCRIPTION
* Skip validation on deserializing pure references

If a deserialization operation is only pointing to something, and making no assertions about it, then we don't need to demand that the referenced model be a valid ActiveRecord.

* Allow trivial up-migration of reference-only views

Unless we want to admit migrations that mutate ids, there's by definition nothing for a migration of a pure reference to do.

This may change with https://github.com/iknow/iknow_view_models/pull/182, so we will want to make sure that that supports renaming in the case of pure references.