### PR TITLE
Visit children in declaration order

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.7.5'
+  VERSION = '3.7.6'
 end


### PR DESCRIPTION
In deserialization, visit attrs/assocs in the order they are declared in the viewmodel class, rather than in the order they appeared in the update hash.

Additionally, removes the redundant checking that the `attributes` in the UpdateData are valid viewmodel members: UpdateData validates this itself during construction.