### PR TITLE
VM::AR::Controller: introduce specified_migration_versions

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.7.6'
+  VERSION = '3.7.7'
 end


### PR DESCRIPTION
Returns all migration versions specified by the client, for consumers that want to use this information directly.