### PR TITLE
Allow expressing create/update to the anonymous child of a singular association

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.7.7'
+  VERSION = '3.8.0'
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -23,6 +23,10 @@ class ViewModel
   #            that child doesn't exist.
   # * nil    - Create a new model if `id` is not specified, otherwise update the
   #            existing record with `id`, and error if it doesn't exist.
+  # * 'auto' - Can only be used when the viewmodel is being deserialized in the
+  #            context of a singular association. `id` must not be specified. If
+  #            the association currently has a child, update it, otherwise
+  #            create a new one.
   NEW_ATTRIBUTE       = '_new'
 
   BULK_UPDATE_TYPE       = '_bulk_update'
@@ -35,20 +39,32 @@ class ViewModel
   MIGRATED_ATTRIBUTE = '_migrated'
 
   Metadata = Struct.new(:id, :view_name, :schema_version, :new, :migrated) do
-    # Does this metadata either explicitly or implicitly describe
-    # deserialization to a new model
+    # Does this metadata describe deserialization to a new model, either by
+    # {new: true} or {new: nil, id: nil}
     def new?
       if new.nil?
         id.nil?
       else
-        new
+        new == true
       end
     end
 
-    # Does this metadata describe an update to the anonymous current existing
+    # Does this metadata describe an change to the anonymous child of a singular
+    # association
+    def child_update?
+      explicit_child_update? || auto_child_update?
+    end
+
+    # Does this metadata describe an update to the already-existing anonymous
     # child of a singular association
-    def implicit_child_update?
+    def explicit_child_update?
       new == false && id.nil?
+    end
+
+    # Does this child metadata describe an create-or-update to the anonymous
+    # child of a singular association
+    def auto_child_update?
+      new == 'auto'
     end
   end
 
@@ -147,6 +163,11 @@ class ViewModel
       schema_version = hash.delete(ViewModel::VERSION_ATTRIBUTE)
       new            = hash.delete(ViewModel::NEW_ATTRIBUTE)
       migrated       = hash.delete(ViewModel::MIGRATED_ATTRIBUTE) { false }
+
+      if id && new == 'auto'
+        raise ViewModel::DeserializationError::InvalidSyntax.new(
+                "An explicit id must not be specified with an 'auto' child update")
+      end
 
       Metadata.new(id, type_name, schema_version, new, migrated)
     end

--- a/lib/view_model/active_record/update_context.rb
+++ b/lib/view_model/active_record/update_context.rb
@@ -134,7 +134,11 @@ class ViewModel::ActiveRecord
 
         updates.each do |ref, update_data|
           viewmodel =
-            if update_data.implicit_child_update?
+            if update_data.auto_child_update?
+              raise ViewModel::DeserializationError::InvalidStructure.new(
+                      'Cannot make an automatic child update to a root node',
+                      ViewModel::Reference.new(update_data.viewmodel_class, nil))
+            elsif update_data.child_update?
               raise ViewModel::DeserializationError::InvalidStructure.new(
                       'Cannot update an existing root node without a specified id',
                       ViewModel::Reference.new(update_data.viewmodel_class, nil))

--- a/lib/view_model/active_record/update_context.rb
+++ b/lib/view_model/active_record/update_context.rb
@@ -134,7 +134,11 @@ class ViewModel::ActiveRecord
 
         updates.each do |ref, update_data|
           viewmodel =
-            if update_data.new?
+            if update_data.implicit_child_update?
+              raise ViewModel::DeserializationError::InvalidStructure.new(
+                      'Cannot update an existing root node without a specified id',
+                      ViewModel::Reference.new(update_data.viewmodel_class, nil))
+            elsif update_data.new?
               viewmodel_class.for_new_model(id: update_data.id)
             else
               viewmodel_class.new(existing_models[update_data.id])

--- a/lib/view_model/active_record/update_data.rb
+++ b/lib/view_model/active_record/update_data.rb
@@ -521,7 +521,11 @@ class ViewModel::ActiveRecord
     end
 
     def new?
-      id.nil? || metadata.new?
+      metadata.new?
+    end
+
+    def implicit_child_update?
+      metadata.implicit_child_update?
     end
 
     def self.parse_hashes(root_subtree_hashes, referenced_subtree_hashes = {})

--- a/lib/view_model/active_record/update_data.rb
+++ b/lib/view_model/active_record/update_data.rb
@@ -520,13 +520,7 @@ class ViewModel::ActiveRecord
       end
     end
 
-    def new?
-      metadata.new?
-    end
-
-    def implicit_child_update?
-      metadata.implicit_child_update?
-    end
+    delegate :new?, :child_update?, :auto_child_update?, to: :metadata
 
     def self.parse_hashes(root_subtree_hashes, referenced_subtree_hashes = {})
       valid_reference_keys = referenced_subtree_hashes.keys.to_set

--- a/lib/view_model/active_record/update_operation.rb
+++ b/lib/view_model/active_record/update_operation.rb
@@ -300,22 +300,26 @@ class ViewModel::ActiveRecord
         case
         when update_data.new?
           child_viewmodel_class.for_new_model(id: update_data.id)
-        when update_data.implicit_child_update?
+        when update_data.child_update?
           if association_data.collection?
             raise ViewModel::DeserializationError::InvalidStructure.new(
                     'Cannot update existing children of a collection association without specified ids',
                     ViewModel::Reference.new(update_data.viewmodel_class, nil))
           end
 
-          existing_child = previous_child_viewmodels[0]
+          child = previous_child_viewmodels[0]
 
-          if existing_child.nil?
-            raise ViewModel::DeserializationError::PreviousChildNotFound.new(
+          if child.nil?
+            unless update_data.auto_child_update?
+              raise ViewModel::DeserializationError::PreviousChildNotFound.new(
                     association_data.association_name.to_s,
                     self.blame_reference)
+            end
+
+            child = child_viewmodel_class.for_new_model
           end
 
-          existing_child
+          child
         when existing_child = previous_by_key[key]
           existing_child
         when taken_child = update_context.try_take_released_viewmodel(key)

--- a/lib/view_model/deserialization_error.rb
+++ b/lib/view_model/deserialization_error.rb
@@ -211,6 +211,23 @@ class ViewModel
       end
     end
 
+    class PreviousChildNotFound < NotFound
+      attr_reader :association
+
+      def initialize(association, blame_nodes)
+        @association = association
+        super(blame_nodes)
+      end
+
+      def detail
+        "No child currently exists to update for association '#{association}'"
+      end
+
+      def meta
+        super.merge(association: association)
+      end
+    end
+
     class DuplicateNodes < InvalidRequest
       attr_reader :type
 

--- a/lib/view_model/schemas.rb
+++ b/lib/view_model/schemas.rb
@@ -21,7 +21,7 @@ class ViewModel::Schemas
       'description' => 'viewmodel update',
       'properties'  => { ViewModel::TYPE_ATTRIBUTE    => { 'type' => 'string' },
                          ViewModel::ID_ATTRIBUTE      => ID_SCHEMA,
-                         ViewModel::NEW_ATTRIBUTE     => { 'type' => 'boolean' },
+                         ViewModel::NEW_ATTRIBUTE     => { 'oneOf' => [{ 'type' => 'boolean' }, { 'type' => 'string', 'enum' => ['auto'] }] },
                          ViewModel::VERSION_ATTRIBUTE => { 'type' => 'integer' } },
       'required'    => [ViewModel::TYPE_ATTRIBUTE],
     }.freeze

--- a/test/unit/view_model/active_record/belongs_to_test.rb
+++ b/test/unit/view_model/active_record/belongs_to_test.rb
@@ -173,6 +173,19 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
     assert_equal(child_id, @model1.child.id)
   end
 
+  def test_belongs_to_one_edit_without_id_no_child
+    @model1.update(child: nil)
+
+    ex = assert_raises(ViewModel::DeserializationError::PreviousChildNotFound) do
+      alter_by_view!(ModelView, @model1) do |view, _refs|
+        view['child'] = { '_type' => 'Child', '_new' => false, 'name' => 'cheese' }
+      end
+    end
+
+    assert_equal('child', ex.association)
+    assert_equal([ViewModel::Reference.new(ModelView, @model1.id)], ex.nodes)
+  end
+
   def test_belongs_to_edit_child_with_auto
     child_id = @model1.child_id
 

--- a/test/unit/view_model/active_record/has_one_test.rb
+++ b/test/unit/view_model/active_record/has_one_test.rb
@@ -186,6 +186,19 @@ class ViewModel::ActiveRecord::HasOneTest < ActiveSupport::TestCase
     assert_equal(child_id, @model1.child.id)
   end
 
+  def test_has_one_edit_without_id_no_child
+    @model1.update(child: nil)
+
+    ex = assert_raises(ViewModel::DeserializationError::PreviousChildNotFound) do
+      alter_by_view!(ModelView, @model1) do |view, _refs|
+        view['child'] = { '_type' => 'Child', '_new' => false, 'name' => 'cheese' }
+      end
+    end
+
+    assert_equal('child', ex.association)
+    assert_equal([ViewModel::Reference.new(ModelView, @model1.id)], ex.nodes)
+  end
+
   def test_belongs_to_edit_child_with_auto
     child_id = @model1.child.id
 

--- a/test/unit/view_model/active_record_test.rb
+++ b/test/unit/view_model/active_record_test.rb
@@ -127,6 +127,30 @@ class ViewModel::ActiveRecordTest < ActiveSupport::TestCase
     assert_equal([ViewModel::Reference.new(ParentView, 9999)], ex.nodes)
   end
 
+  def test_create_implicit_id_raises
+    view = {
+      '_type' => 'Parent',
+      '_new'  => false,
+    }
+    ex = assert_raises(ViewModel::DeserializationError::InvalidStructure) do
+      ParentView.deserialize_from_view(view)
+    end
+    assert_match(/existing root node without a specified id/, ex.message)
+    assert_equal([ViewModel::Reference.new(ParentView, nil)], ex.nodes)
+  end
+
+  def test_create_auto_raises
+    view = {
+      '_type' => 'Parent',
+      '_new'  => 'auto',
+    }
+    ex = assert_raises(ViewModel::DeserializationError::InvalidStructure) do
+      ParentView.deserialize_from_view(view)
+    end
+    assert_match(/automatic child update to a root node/, ex.message)
+    assert_equal([ViewModel::Reference.new(ParentView, nil)], ex.nodes)
+  end
+
   def test_read_only_raises_with_id
     view = {
       '_type' => 'Parent',


### PR DESCRIPTION
This requires two extensions, to be able to express both "update existing" or "create-or-update".

We do this with extensions to the interpretation of `_new`:
  * `true`  - Always create a new model, using the id if provided, error if          a model with that id already exists
  * `false` - Never create a new model. **If id isn’t provided, it's an error            unless the viewmodel is being deserialized in the context of a            singular association, in which case it's implicitly referring            to the current child of that association, and is an error if            that child doesn't exist.**
 * `nil`    - Create a new model if `id` is not specified, otherwise update the            existing record with `id`, and error if it doesn't exist.
 * `'auto'` - **Can only be used when the viewmodel is being deserialized in the            context of a singular association. `id` must not be specified. If            the association currently has a child, update it, otherwise            create a new one.**

