### PR TITLE
cache delete: permissive calling convention

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.9.0'
+  VERSION = '3.9.1'
 end

--- a/lib/view_model/active_record/cache.rb
+++ b/lib/view_model/active_record/cache.rb
@@ -49,8 +49,12 @@ class ViewModel::ActiveRecord::Cache
     @migrated_cache = @migrated_cache_group.register_cache(cache_name)
   end
 
+  # Handles being called with either ids or model/viewmodel objects
   def delete(*ids)
     ids.each do |id|
+      id = id.id if id.respond_to?(:id)
+      raise ArgumentError.new unless id.is_a?(Numeric) || id.is_a?(String)
+
       @cache_group.delete_all(@cache.key.new(id))
     end
   end


### PR DESCRIPTION
Mimic convenience overloads by runtime type-checking the arguments, to accept ~either an array or~ splat of ids or model/viewmodel objects.