### PR TITLE
Deserialization: visit members in declaration order if possible

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.8.0'
+  VERSION = '3.9.0'
 end


### PR DESCRIPTION
We require members to be visited in declaration order so that we can safely
write viewmodels for models whose members have dependencies on the values of
other members.

We're limited to deserializing points-to and pointed-from associations before
and after save respectively, but we can at least correctly interleave attributes
and points-to associations.
