### PR TITLE
VM::Cache: retry without using cache on stale cached references

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.10.0'
+  VERSION = '3.10.1'
 end


### PR DESCRIPTION
If a cached value contains a reference to a entity that no longer exists, this currently results in a RecordNotFound error. Instead, we should be able to treat this as a signal that the cached value is out of date, and re-resolve it from the database.