### PR TITLE
Support atomic batch deletion

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.10.1'
+  VERSION = '3.11.0'
 end

--- a/lib/view_model/active_record/controller_base.rb
+++ b/lib/view_model/active_record/controller_base.rb
@@ -156,11 +156,13 @@ module ActionDispatch
                   name_route = { as: '' } # Only one route may take the name
                   post('', action: :create, **name_route.extract!(:as)) unless except.include?(:create) || !add_shallow_routes
                   get('',  action: :index,  **name_route.extract!(:as)) unless except.include?(:index)  || !add_shallow_routes
+                  delete('', action: :destroy, as: :bulk_delete) unless except.include?(:destroy) || !add_shallow_routes
                 end
               end
             else
               collection do
                 get('', action: :index, as: '') unless except.include?(:index)
+                delete('', action: :destroy, as: :bulk_delete) unless except.include?(:destroy)
               end
             end
           end

--- a/test/unit/view_model/active_record/controller_test.rb
+++ b/test/unit/view_model/active_record/controller_test.rb
@@ -167,6 +167,22 @@ class ViewModel::ActiveRecord::ControllerTest < ActiveSupport::TestCase
   end
 
   def test_destroy
+    other_parent = make_parent
+    parentcontroller = ParentController.new(params: { id: [@parent.id, other_parent.id] })
+    parentcontroller.invoke(:destroy)
+
+    assert_equal(200, parentcontroller.status)
+
+    assert(Parent.where(id: @parent.id).blank?, "record doesn't exist after delete")
+    assert(Parent.where(id: other_parent.id).blank?, "record doesn't exist after delete")
+
+    assert_equal({ 'data' => nil },
+                 parentcontroller.hash_response)
+
+    assert_all_hooks_nested_inside_parent_hook(parentcontroller.hook_trace)
+  end
+
+  def test_batch_destroy
     parentcontroller = ParentController.new(params: { id: @parent.id })
     parentcontroller.invoke(:destroy)
 


### PR DESCRIPTION
The VM::AR controller destroy action now optionally parses multiple ids for
deletion, and the action is aliased as a collection route as well as a member
route.

Deletion is performed one at a time within the same transaction.