### PR TITLE
Migration validations

### DIFF
--- a/lib/view_model/migratable_view.rb
+++ b/lib/view_model/migratable_view.rb
@@ -10,9 +10,9 @@ module ViewModel::MigratableView
   extend ActiveSupport::Concern
 
   class_methods do
-    def inherited(base)
+    def inherited(subclass)
       super
-      base.initialize_as_migratable_view
+      subclass.initialize_as_migratable_view
     end
 
     def initialize_as_migratable_view


### PR DESCRIPTION
Adds a mechanism for verifying that migrations aren't missed: if all migrations are defined in a `migrations { ... }` block, and we add a `no_migration!` to declare an intentionally absent version, then we can validate for completeness on block exit, and raise a NoPathError if any version is undeclared.