### PR TITLE
Allow metadata references

### DIFF
--- a/lib/view_model/migratable_view.rb
+++ b/lib/view_model/migratable_view.rb
@@ -10,9 +10,9 @@ module ViewModel::MigratableView
   extend ActiveSupport::Concern
 
   class_methods do
-    def inherited(base)
+    def inherited(subclass)
       super
-      base.initialize_as_migratable_view
+      subclass.initialize_as_migratable_view
     end
 
     def initialize_as_migratable_view

--- a/lib/view_model/references.rb
+++ b/lib/view_model/references.rb
@@ -30,6 +30,14 @@ class ViewModel
       ref
     end
 
+    def add_preserialized_reference(ref, literal_value)
+      return ref if @value_by_ref.has_key?(ref)
+
+      @ref_by_value[literal_value] = ref
+      @value_by_ref[ref] = literal_value
+      ref
+    end
+
     def clear!
       @ref_by_value.clear
       @value_by_ref.clear

--- a/lib/view_model/serialize_context.rb
+++ b/lib/view_model/serialize_context.rb
@@ -19,7 +19,7 @@ class ViewModel::SerializeContext < ViewModel::TraversalContext
   end
 
   delegate :references, :flatten_references, to: :shared_context
-  delegate :add_reference, :has_references?, to: :references
+  delegate :add_reference, :add_preserialized_reference, :has_references?, to: :references
 
   # Return viewmodels referenced during serialization and clear @references.
   def extract_referenced_views!

--- a/test/unit/view_model/controller_test.rb
+++ b/test/unit/view_model/controller_test.rb
@@ -18,6 +18,7 @@ class ViewModel::ControllerTest < ActiveSupport::TestCase
     let(:controller) do
       Class.new do
         def self.rescue_from(*); end
+        def self.etag(*); end
         include ViewModel::Controller
         public :encode_jbuilder
       end


### PR DESCRIPTION
Reference serialization in prerender_viewmodel/prerender_json_view is now deferred until after the optional metadata block. The block is now allowed to contribute references to the `serialize_context` which will be included in the final references serialization.

SerializeContext gains a new `add_preserialized_reference` to permit recording a pre-serialized reference literal.