### PR TITLE
Deserialization includes

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.12.1'
+  VERSION = '3.13.0'
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -192,9 +192,18 @@ class ViewModel
     end
 
     # If this viewmodel represents an AR model, what associations does it make
-    # use of? Returns a includes spec appropriate for DeepPreloader, either as
-    # AR-style nested hashes or DeepPreloader::Spec.
+    # use of during serialization? Returns a includes spec appropriate for
+    # DeepPreloader, either as AR-style nested hashes or DeepPreloader::Spec.
     def eager_includes(include_referenced: true)
+      {}
+    end
+
+    # If this viewmodel represents an AR model, what associations does it make
+    # use of during deserialization? By default all mentioned associations are
+    # preloaded, however access controls and hooks may benefit from additional
+    # preloading. Returns a includes spec appropriate for DeepPreloader, either
+    # as AR-style nested hashes or DeepPreloader::Spec.
+    def deserialization_includes
       {}
     end
 

--- a/lib/view_model/active_record/update_data.rb
+++ b/lib/view_model/active_record/update_data.rb
@@ -635,7 +635,12 @@ class ViewModel::ActiveRecord
         deps[association_data.direct_reflection.name.to_s] = referenced_deps
       end
 
-      DeepPreloader::Spec.new(deps)
+      deserialization_includes = viewmodel_class.deserialization_includes
+      unless deserialization_includes.is_a?(DeepPreloader::AbstractSpec)
+        deserialization_includes = DeepPreloader::Spec.parse(deserialization_includes)
+      end
+
+      DeepPreloader::Spec.new(deps).merge!(deserialization_includes)
     end
 
     def viewmodel_reference

--- a/test/unit/view_model/active_record/belongs_to_test.rb
+++ b/test/unit/view_model/active_record/belongs_to_test.rb
@@ -443,4 +443,26 @@ class ViewModel::ActiveRecord::BelongsToTest < ActiveSupport::TestCase
       end
     end
   end
+
+  class DeserializationIncludeTest < ActiveSupport::TestCase
+    include ARVMTestUtilities
+    include ViewModelSpecHelpers::Base
+
+    def model_attributes
+      super.merge(
+        viewmodel: ->(_v) {
+          def self.deserialization_includes
+            :child
+          end
+        }
+      )
+    end
+
+    def test_extra_dependencies
+      viewmodel_class # realize lazy dependency
+
+      root_updates, _ref_updates = ViewModel::ActiveRecord::UpdateData.parse_hashes([{ '_type' => 'Model' }])
+      assert_equal(DeepPreloader::Spec.new('child' => nil), root_updates.first.preload_dependencies)
+    end
+  end
 end


### PR DESCRIPTION
This enables unconditional eager loading during the deserialization phase, which can be used to ensure that models are loaded in access controls and hooks.
