### PR TITLE
Pass include_referenced to preloadable_dependencies

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.14.1'
+  VERSION = '3.14.2'
 end

--- a/lib/view_model.rb
+++ b/lib/view_model.rb
@@ -338,7 +338,7 @@ class ViewModel
 
     def preload_for_serialization(viewmodels, include_referenced: true, lock: nil)
       Array.wrap(viewmodels)
-        .flat_map(&:preloadable_dependencies)
+        .flat_map { |v| v.preloadable_dependencies(include_referenced: include_referenced) }
         .group_by(&:class)
         .each do |type, views|
           DeepPreloader.preload(views.map(&:model),
@@ -434,7 +434,7 @@ class ViewModel
   # on that can have their dependencies preloaded via `eager_includes`. This can
   # be overridden for non-AR view that wrap AR-backed views to expose those
   # dependencies for preloading.
-  def preloadable_dependencies
+  def preloadable_dependencies(include_referenced: true)
     []
   end
 

--- a/lib/view_model/active_record.rb
+++ b/lib/view_model/active_record.rb
@@ -450,7 +450,7 @@ class ViewModel::ActiveRecord < ViewModel::Record
   end
 
   # As an AR view, this view itself is preloadable
-  def preloadable_dependencies
+  def preloadable_dependencies(include_referenced: true)
     [self]
   end
 


### PR DESCRIPTION
If a non-AR wrapping view is delegating its preloadable dependencies to children, those children might be referenced children, in which case it's important to distinguish so that the tree can be truncated in the case of include_references: false.