### PR TITLE
Support down-migrations that need to premigrate to intermediates

### DIFF
--- a/lib/iknow_view_models/version.rb
+++ b/lib/iknow_view_models/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module IknowViewModels
-  VERSION = '3.14.2'
+  VERSION = '3.14.3'
 end

--- a/lib/view_model/migratable_view.rb
+++ b/lib/view_model/migratable_view.rb
@@ -19,14 +19,15 @@ module ViewModel::MigratableView
       @migrations_lock   = Monitor.new
       @migration_classes = {}
       @migration_paths   = {}
-      @realized_migration_paths = true
     end
 
     def migration_path(from:, to:)
       @migrations_lock.synchronize do
-        realize_paths! unless @realized_migration_paths
+        unless @migration_paths.has_key?(to)
+          @migration_paths[to] = compute_migration_paths(to)
+        end
 
-        migrations = @migration_paths.fetch([from, to]) do
+        migrations = @migration_paths[to].fetch(from) do
           raise ViewModel::Migration::NoPathError.new(self, from, to)
         end
 
@@ -64,25 +65,35 @@ module ViewModel::MigratableView
         const_set(:"Migration_#{from}_To_#{to}", migration_class)
         @migration_classes[[from, to]] = migration_class
 
-        @realized_migration_paths = false
+        clear_migration_paths!
+      end
+    end
+
+    def clear_migration_paths!
+      @migrations_lock.synchronize do
+        @migration_paths.clear
       end
     end
 
     # Internal: find and record possible paths to the current schema version.
-    def realize_paths!
-      @migration_paths.clear
+    def compute_migration_paths(to_version)
+      unless to_version <= self.schema_version
+        raise RuntimeError.new("Cannot compute path to future version '#{to_version}'")
+      end
 
       graph = RGL::DirectedAdjacencyGraph.new
 
-      # Add a vertex for the current version, in case no edges reach it
-      graph.add_vertex(self.schema_version)
+      # Add a vertex for the destination version, in case no edges reach it
+      graph.add_vertex(to_version)
 
       # Add edges backwards, as we care about paths from the latest version
       @migration_classes.each_key do |from, to|
         graph.add_edge(to, from)
       end
 
-      paths = graph.dijkstra_shortest_paths(Hash.new { 1 }, self.schema_version)
+      paths = graph.dijkstra_shortest_paths(Hash.new { 1 }, to_version)
+
+      result = {}
 
       paths.each do |target_version, path|
         next if path.nil? || path.length == 1
@@ -92,12 +103,10 @@ module ViewModel::MigratableView
           @migration_classes.fetch([from, to])
         end
 
-        key = [target_version, schema_version]
-
-        @migration_paths[key] = path_migration_classes.map(&:new)
+        result[target_version] = path_migration_classes.map(&:new)
       end
 
-      @realized_paths = true
+      result
     end
   end
 end

--- a/lib/view_model/migrator.rb
+++ b/lib/view_model/migrator.rb
@@ -23,16 +23,15 @@ class ViewModel
       end
     end
 
-    def initialize(required_versions)
-      @paths = required_versions.each_with_object({}) do |(viewmodel_class, required_version), h|
-        if required_version != viewmodel_class.schema_version
-          path = viewmodel_class.migration_path(from: required_version, to: viewmodel_class.schema_version)
-          h[viewmodel_class.view_name] = path
-        end
-      end
+    MigrationPlan = Struct.new(:path, :required_version, :current_version, :viewmodel_class)
 
-      @versions = required_versions.each_with_object({}) do |(viewmodel_class, required_version), h|
-        h[viewmodel_class.view_name] = [required_version, viewmodel_class.schema_version]
+    def initialize(required_versions)
+      @plans = required_versions.each_with_object({}) do |(viewmodel_class, required_version), h|
+        current_version = viewmodel_class.schema_version
+        next if required_version == current_version
+
+        path = viewmodel_class.migration_path(from: required_version, to: current_version)
+        h[viewmodel_class.view_name] = MigrationPlan.new(path, required_version, current_version, viewmodel_class)
       end
     end
 
@@ -128,23 +127,22 @@ class ViewModel
     end
 
     def migrate_viewmodel!(view_name, source_version, view_hash, references)
-      path = @paths[view_name]
-      return false unless path
+      plan = @plans[view_name]
+      return false unless plan
 
-      required_version, current_version = @versions[view_name]
-      return false if source_version == current_version
+      return false if source_version == plan.current_version
 
       # We assume that an unspecified source version is the same as the required
       # version (i.e. the version demanded by the client request).
-      unless source_version.nil? || source_version == required_version
+      unless source_version.nil? || source_version == plan.required_version
         raise ViewModel::Migration::UnspecifiedVersionError.new(view_name, source_version)
       end
 
-      path.each do |migration|
+      plan.path.each do |migration|
         migration.up(view_hash, references)
       end
 
-      view_hash[ViewModel::VERSION_ATTRIBUTE] = current_version
+      view_hash[ViewModel::VERSION_ATTRIBUTE] = plan.current_version
 
       true
     end
@@ -156,15 +154,23 @@ class ViewModel
     private
 
     def migrate_viewmodel!(view_name, source_version, view_hash, references)
-      path = @paths[view_name]
-      return false unless path
+      plan = @plans[view_name]
+      return false unless plan
 
       # In a serialized output, the source version should always be the present
       # and the current version, unless already modified by a parent migration
-      required_version, current_version = @versions[view_name]
-      return false if source_version == required_version
+      return false if source_version == plan.required_version
 
-      unless source_version == current_version
+      # If a parent migration has already partially migrated us to an
+      # intermediate version, we need to construct a new path to the required
+      # version.
+      if source_version == plan.current_version
+        path = plan.path
+      elsif view_hash[ViewModel::MIGRATED_ATTRIBUTE] &&
+            source_version > plan.required_version &&
+            source_version < plan.current_version
+        path = plan.viewmodel_class.migration_path(from: plan.required_version, to: source_version)
+      else
         raise ViewModel::Migration::UnspecifiedVersionError.new(view_name, source_version)
       end
 
@@ -172,7 +178,7 @@ class ViewModel
         migration.down(view_hash, references)
       end
 
-      view_hash[ViewModel::VERSION_ATTRIBUTE] = required_version
+      view_hash[ViewModel::VERSION_ATTRIBUTE] = plan.required_version
 
       true
     end

--- a/test/unit/view_model/active_record/migration_test.rb
+++ b/test/unit/view_model/active_record/migration_test.rb
@@ -483,6 +483,87 @@ class ViewModel::ActiveRecord::Migration < ActiveSupport::TestCase
     end
   end
 
+  describe 'partially migrating children' do
+    include ViewModelSpecHelpers::ParentAndBelongsToChild
+    let(:migration_versions) { { viewmodel_class => 1, child_viewmodel_class => 1 } }
+
+    # Parent 2->1 requires premigrating child 3->2
+    def model_attributes
+      child_viewmodel_class = self.child_viewmodel_class
+      super.merge(
+        viewmodel: ->(_v) {
+          self.schema_version = 2
+
+          # The migration from 1 -> 2 relies on a field only present in child v2
+          migrates from: 1, to: 2 do
+            down do |view, references|
+              child = view['child']
+
+              if child['_version'] > 2
+                migrator = ViewModel::DownMigrator.new({ child_viewmodel_class => 2 })
+                migrator.migrate!({ 'data' => child, 'references' => references.deep_dup })
+              end
+
+              view['child_v2_field'] = child['v2_field']
+            end
+          end
+        },
+      )
+    end
+
+    def child_attributes
+      super().merge(
+        viewmodel: ->(_v) {
+          self.schema_version = 3
+          migrates from: 1, to: 2 do
+            down do |view, _references|
+              view.delete('v2_field')
+            end
+          end
+
+          migrates from: 2, to: 3 do
+            down do |view, _references|
+              view['v2_field'] = 'v2_field_data'
+            end
+          end
+        })
+    end
+
+    let(:v1_serialization_data) do
+      {
+        ViewModel::TYPE_ATTRIBUTE => viewmodel_class.view_name,
+        ViewModel::VERSION_ATTRIBUTE => 1,
+        ViewModel::ID_ATTRIBUTE => viewmodel.id,
+        'name' => viewmodel.name,
+        'child' => {
+          ViewModel::TYPE_ATTRIBUTE => child_viewmodel_class.view_name,
+          ViewModel::VERSION_ATTRIBUTE => 1,
+          ViewModel::ID_ATTRIBUTE => viewmodel.child.id,
+          'name' => viewmodel.child.name,
+        },
+        'child_v2_field' => 'v2_field_data',
+      }
+    end
+
+    let(:migrator) { down_migrator }
+    let(:subject) do
+      current_serialization.deep_dup
+    end
+
+    let(:expected_result) do
+      data = v1_serialization_data.deep_dup
+      data[ViewModel::MIGRATED_ATTRIBUTE] = true
+      data['child'][ViewModel::MIGRATED_ATTRIBUTE] = true
+
+      { 'data' => data }
+    end
+
+    it 'migrates' do
+      migrate!
+      assert_equal(expected_result, subject)
+    end
+  end
+
   describe 'concurrently inserting a reference' do
     include ViewModelSpecHelpers::ReferencedList
     let(:migration_versions) { { viewmodel_class => 1 } }


### PR DESCRIPTION
When a migration moves attributes from one view to another, it might be necessary to premigrate a referenced view to obtain those attributes in the correct shape. But the contemporary version that it needs to be premigrated to might not be the eventual destination of that view, which isn't compatible with the current down-migrator.

Extend the down-migrator to support completing the down-migration of a partially-migrated intermediate.